### PR TITLE
feat(legislation): in-game time-based bill lifecycle (pacing pass)

### DIFF
--- a/docs/research/pacing-legislative-timeline-2026-04.md
+++ b/docs/research/pacing-legislative-timeline-2026-04.md
@@ -1,0 +1,112 @@
+# Pacing Pass — Legislative Timeline (April 2026)
+
+**Branch:** `exp--pacing-legislative-timeline`
+**Issue:** Legislative pacing — bills pass in seconds, no sense of time or political process.
+
+---
+
+## 1. Problem
+
+In the alpha build, a player can take a bill from `draft` → `committee` → `floor_debate` → `vote` → `signed` in four consecutive button clicks. The only cost is Political Capital. No in-game days elapse. There is:
+
+- **No sense that legislation is a *process*** — it's a button-mashing ritual.
+- **No opportunity cost** — if you have PC, you advance. Waiting offers nothing, so players never wait.
+- **No pressure on the clock** — bills don't compete with each other for floor time, and they don't decay if ignored.
+- **No forecast** — the player sees a raw "Opposition 55" number but cannot estimate passage chance before committing.
+
+This is the core pacing defect the player feels first, because the Legislation panel is the main loop.
+
+## 2. Design principles
+
+1. **Time is the primary cost.** Stages take in-game days to resolve. A player cannot simply pay to skip process entirely — the legislative calendar is the gate.
+2. **PC is an optional accelerator.** Players who *must* rush a bill can spend PC to skip remaining days in a stage. The price of acceleration is deliberately steep so the default play is to wait.
+3. **Waiting is not dead time.** While a bill sits in committee or on the floor, small things can happen (amendments offered, coalitions shift, opposition hardens). This turns the calendar into a drama generator.
+4. **The player can plan.** A forecasted passage chance and a days-remaining readout make waiting *productive* thought, not idle waiting.
+
+## 3. Numbers (v1)
+
+| Stage | Default days | PC to expedite (skip full remainder) |
+|---|---|---|
+| `draft` | 0 (instantaneous — bill is written) | — |
+| `committee` | 21 days | 25 PC |
+| `floor_debate` | 14 days | 20 PC |
+| `vote` | 7 days (scheduling) | 15 PC |
+
+**Total baseline timeline:** `draft` click → `signed/failed` in roughly 42 in-game days (6 weeks). At speed 1× (1 day / real second default), that's about 42 seconds of real wait with the clock running — enough to feel like a process, short enough to stay engaging.
+
+Tunable per bill via an optional `stageDurations` field on `BillTemplate`; constitutional amendments, emergency appropriations, and omnibus bills can override.
+
+## 4. Implementation surface
+
+### 4.1 Types (`src/types/legislation.ts`)
+
+```ts
+export interface Bill {
+  // ... existing fields ...
+  /** Simulated day index on which the bill entered its current stage. */
+  stageEnteredOnDay: number;
+  /** Target day on which the current stage auto-advances. */
+  stageEndsOnDay: number;
+}
+
+export interface BillTemplate {
+  // ... existing fields ...
+  /** Optional per-stage duration override (in days). Defaults in `LegislationSystem`. */
+  stageDurations?: Partial<Record<'committee' | 'floor_debate' | 'vote', number>>;
+}
+```
+
+Add a `simDay` helper — an absolute day counter kept on `gameStore` so bills can be compared against a monotonic number rather than wrestling with `GameDate` arithmetic. Initialized to 0 on scenario start; incremented by `TimeEngine` on every daily tick.
+
+### 4.2 System (`src/systems/LegislationSystem.ts`)
+
+- `draftBill()` now pushes the bill to `committee` immediately with `stageEndsOnDay = simDay + 21` (default).
+- `advanceStage()` becomes `expediteStage()` — pays PC to jump to the end of the current stage's clock. Same cost schedule as today but expressed as "skip N days early" fees.
+- `dailyUpdate()` (new) walks pending bills; if `simDay >= stageEndsOnDay`, advance to the next stage (free) and reset the timer. Vote stage auto-resolves via `resolveVote` on clock expiry.
+- `estimatePassageChance(billId)` returns a deterministic probability (mean of the per-legislator vote-probabilities without RNG). Used by the UI forecast.
+
+### 4.3 Engine wiring (`src/engine/GameEngine.ts`)
+
+- `TimeEngine.onDaily` now also calls `LegislationSystem.dailyUpdate()`.
+- Add `simDay` increment to the daily hook.
+
+### 4.4 UI (`src/renderer/panels/LegislationPanel.tsx`)
+
+Pending-bill card:
+- Shows current stage with a progress bar: `Committee · day 5 / 21`.
+- When stage ends naturally, no click needed — card transitions on the next daily tick.
+- Primary button: `Expedite (25 PC)` — visible only when the stage has PC cost and bill is not already at vote stage expiring this tick.
+- Secondary button: `Withdraw` (existing affordance) — unchanged.
+
+Draft-New card:
+- Adds a `Forecast: 62% pass` badge derived from `estimatePassageChance()` applied to the *template* (i.e. pretends the bill were introduced today).
+- Sorts by forecast descending by default; user can toggle to alphabetical.
+
+### 4.5 Data
+
+Existing `bill-templates.json` entries are untouched; the defaults apply. The `Constitutional Moment` card and `Immigration & Border Reform` bill can later receive `stageDurations` overrides.
+
+### 4.6 Tests
+
+- Vitest — `LegislationSystem.dailyUpdate` auto-advances at the correct day boundary; PC not deducted; vote resolves on vote-stage expiry.
+- Vitest — `estimatePassageChance` is deterministic for a given `(bill, Congress, character)` triple.
+- Vitest — `expediteStage` fails gracefully on insufficient PC.
+- Playwright — smoke: draft a bill, run 22 days at 4× speed, confirm bill has advanced to `floor_debate`.
+
+### 4.7 Out of scope for this PR
+
+- Amendment system (would require event hooks into bills in flight — planned, separate).
+- Floor-time competition (only one bill can hold the floor — planned, separate).
+- Bill decay / shelf time (bills that sit in committee forever should eventually die — planned, separate).
+- Any changes to AP, card draw, or skill pacing — explicitly out.
+
+Follow-up issues to file once this merges:
+1. "Legislation: amendment events during committee wait"
+2. "Legislation: one bill on the floor at a time"
+3. "Legislation: committee death after N days of neglect"
+
+## 5. Risks
+
+- **Players who had muscle memory of 'click advance 3 times'** will notice the change. The expedite button preserves that playstyle with a cost.
+- **Clock-dependent behaviour is harder to unit-test** — mitigated by the deterministic `simDay` counter and by tests that advance `simDay` explicitly rather than waiting for real time.
+- **Save/load format** grows by two integers per pending bill. Additive change, no migration needed because these fields can be derived from `stage` + current date for legacy saves (treat `stageEnteredOnDay` as `simDay` on load and give the bill a fresh clock).

--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -89,6 +89,10 @@ class GameEngineImpl implements GameEngineAPI {
     EventEngine.registerEvents(bundle.events);
     QuestSystem.register(bundle.quests);
     AchievementEngine.registerAchievements(bundle.achievements);
+    // Legislation needs access to the bill catalogue (for per-template
+    // stage-duration overrides) without importing GameEngine itself, which
+    // would create a module cycle.
+    LegislationSystem.registerTemplates(bundle.billTemplates);
     log.info('data registered', {
       scenarios: bundle.scenarios.length,
       cards: bundle.cards.length,
@@ -184,6 +188,11 @@ class GameEngineImpl implements GameEngineAPI {
       TimeEngine.onDaily(() => {
         EventEngine.checkDailyTriggers();
         QuestSystem.dailyUpdate();
+        // Legislative clock: bills march through committee → floor → vote
+        // on a per-day basis. Without this hook, bills would be frozen in
+        // whichever stage they were drafted into. See
+        // docs/research/pacing-legislative-timeline-2026-04.md.
+        LegislationSystem.dailyUpdate();
       }),
       TimeEngine.onWeekly(() => {
         PopulationSystem.weeklyUpdate();

--- a/src/renderer/panels/LegislationPanel.tsx
+++ b/src/renderer/panels/LegislationPanel.tsx
@@ -1,18 +1,35 @@
 import { useMemo, useState } from 'react';
 import { GameEngine } from '@/engine/GameEngine';
-import { LegislationSystem } from '@/systems/LegislationSystem';
+import {
+  LegislationSystem,
+  EXPEDITE_PC_COST,
+  STAGE_DURATION_DAYS,
+} from '@/systems/LegislationSystem';
 import { useWorldStore } from '@/store/worldStore';
 import { useGameStore } from '@/store/gameStore';
 import { useUIStore } from '@/store/uiStore';
+import { toEpochDays } from '@/utils/date';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
-import type { BillId, BillTemplate } from '@/types';
+import { Bar } from '../components/Bar';
+import type { Bill, BillId, BillStage, BillTemplate } from '@/types';
 
 /**
- * LegislationPanel — draft, advance, and vote on bills.
+ * LegislationPanel — draft, track, expedite, and vote on bills.
  *
- * Stage advance and vote resolution are performed here by calling
- * `LegislationSystem` directly; all store writes happen inside that module.
+ * After the April 2026 pacing pass, bills progress through committee →
+ * floor debate → vote on a day-by-day clock driven by
+ * `LegislationSystem.dailyUpdate`. The player has two levers in this panel:
+ *
+ *  1. **Draft** — introduce a new bill into committee. A forecast badge
+ *     shows the estimated passage chance so the player can decide whether
+ *     the bill is worth the PC investment *before* spending political
+ *     capital on it.
+ *  2. **Expedite** — skip the remainder of the current stage's clock by
+ *     paying PC. Rarely the right move early in a term, often the right
+ *     move near election day.
+ *
+ * Time alone will carry a bill to a vote. PC only accelerates.
  */
 export function LegislationPanel(): JSX.Element {
   const templates = useMemo(() => GameEngine.getBillTemplates(), []);
@@ -20,7 +37,12 @@ export function LegislationPanel(): JSX.Element {
   const passed = useWorldStore((s) => s.passedLegislation);
   const failed = useWorldStore((s) => s.failedLegislation);
   const pc = useGameStore((s) => s.politicalCapital);
+  const currentDate = useGameStore((s) => s.currentDate);
   const pushToast = useUIStore((s) => s.pushToast);
+
+  // Today's monotonic day index. Re-derived from `currentDate` on each
+  // render so the progress bars advance the moment the clock ticks.
+  const today = toEpochDays(currentDate);
 
   const [tab, setTab] = useState<'draft' | 'pending' | 'archive'>('pending');
 
@@ -30,12 +52,10 @@ export function LegislationPanel(): JSX.Element {
     setTab('pending');
   }
 
-  function advance(id: BillId): void {
-    const res = LegislationSystem.advanceStage(id);
+  function expedite(id: BillId): void {
+    const res = LegislationSystem.expediteStage(id);
     if (!res.ok) {
-      pushToast({ message: res.reason ?? 'Cannot advance', severity: 'warning', ttl: 3000 });
-    } else if (res.newStage === 'vote') {
-      pushToast({ message: 'Bill reached floor vote', severity: 'info', ttl: 3000 });
+      pushToast({ message: res.reason ?? 'Cannot expedite', severity: 'warning', ttl: 3000 });
     }
   }
 
@@ -43,12 +63,21 @@ export function LegislationPanel(): JSX.Element {
     const res = LegislationSystem.resolveVote(id);
     pushToast({
       message: res.passed
-        ? `PASSED ${res.yea}–${res.nay}`
-        : `FAILED ${res.yea}–${res.nay}`,
+        ? `PASSED ${res.yea}\u2013${res.nay}`
+        : `FAILED ${res.yea}\u2013${res.nay}`,
       severity: res.passed ? 'success' : 'danger',
       ttl: 4000,
     });
   }
+
+  // Sort drafts descending by estimated passage chance so the player's
+  // best options surface first.
+  const rankedTemplates = useMemo(() => {
+    return [...templates].sort(
+      (a, b) =>
+        LegislationSystem.estimatePassageChance(b) - LegislationSystem.estimatePassageChance(a),
+    );
+  }, [templates]);
 
   return (
     <div>
@@ -66,48 +95,57 @@ export function LegislationPanel(): JSX.Element {
 
       {tab === 'draft' && (
         <div className="grid md:grid-cols-2 gap-3">
-          {templates.map((t) => (
-            <Card key={t.id} title={t.title} accent="blue">
-              <p className="text-sm text-text-secondary mb-2">{t.description}</p>
-              <div className="text-xs text-text-muted flex flex-wrap gap-2 mb-3">
-                {t.tags.map((tag) => (
-                  <span key={tag} className="bg-bg-tertiary rounded px-2 py-0.5">{tag}</span>
-                ))}
-                <span className="ml-auto">Opposition {t.opposition}</span>
-              </div>
-              <Button variant="primary" size="sm" onClick={() => draft(t)}>
-                Draft
-              </Button>
-            </Card>
-          ))}
+          {rankedTemplates.map((t) => {
+            const chance = LegislationSystem.estimatePassageChance(t);
+            const totalDays =
+              (t.stageDurations?.committee ?? STAGE_DURATION_DAYS.committee) +
+              (t.stageDurations?.floor_debate ?? STAGE_DURATION_DAYS.floor_debate) +
+              (t.stageDurations?.vote ?? STAGE_DURATION_DAYS.vote);
+            return (
+              <Card key={t.id} title={t.title} accent="gold">
+                <p className="text-sm text-text-secondary mb-2">{t.description}</p>
+                <div className="text-xs text-text-muted flex flex-wrap gap-2 mb-3">
+                  {t.tags.map((tag) => (
+                    <span key={tag} className="bg-bg-tertiary rounded px-2 py-0.5">
+                      {tag}
+                    </span>
+                  ))}
+                  <span className="ml-auto">Opposition {t.opposition}</span>
+                </div>
+                <div className="flex items-center gap-3 mb-3 text-xs">
+                  <span
+                    className={`px-2 py-0.5 rounded font-mono ${chanceToneClass(chance)}`}
+                    title="Estimated passage probability based on current Senate composition, relationships, and opposition."
+                  >
+                    Forecast: {Math.round(chance * 100)}% pass
+                  </span>
+                  <span className="text-text-muted">~{totalDays} days to vote</span>
+                </div>
+                <Button variant="primary" size="sm" onClick={() => draft(t)}>
+                  Draft
+                </Button>
+              </Card>
+            );
+          })}
         </div>
       )}
 
       {tab === 'pending' && (
         <div className="space-y-3">
           {pending.length === 0 && (
-            <p className="text-sm text-text-muted italic">No bills in flight. Draft one to get started.</p>
+            <p className="text-sm text-text-muted italic">
+              No bills in flight. Draft one to get started.
+            </p>
           )}
           {pending.map((b) => (
-            <Card key={b.id} title={b.title} subtitle={`Stage: ${b.stage}`} accent="gold">
-              <p className="text-sm text-text-secondary mb-3">{b.description}</p>
-              <div className="flex items-center gap-3 text-xs text-text-muted mb-3">
-                <span>Opposition: {b.opposition}</span>
-                <span>PC invested: {b.pcInvested}</span>
-                <span>Support: {b.supportVotes} / Oppose: {b.opposeVotes}</span>
-              </div>
-              <div className="flex gap-2">
-                {b.stage !== 'vote' ? (
-                  <Button size="sm" variant="primary" onClick={() => advance(b.id)} disabled={pc < 10}>
-                    Advance stage
-                  </Button>
-                ) : (
-                  <Button size="sm" variant="gold" onClick={() => vote(b.id)}>
-                    Call the vote
-                  </Button>
-                )}
-              </div>
-            </Card>
+            <PendingBillCard
+              key={b.id}
+              bill={b}
+              today={today}
+              pc={pc}
+              onExpedite={() => expedite(b.id)}
+              onVote={() => vote(b.id)}
+            />
           ))}
         </div>
       )}
@@ -117,14 +155,14 @@ export function LegislationPanel(): JSX.Element {
           {passed.map((b) => (
             <Card key={b.id} title={b.title} subtitle="Passed" accent="gold">
               <p className="text-xs text-text-muted">
-                Yea {b.supportVotes} – Nay {b.opposeVotes}
+                Yea {b.supportVotes} &ndash; Nay {b.opposeVotes}
               </p>
             </Card>
           ))}
           {failed.map((b) => (
             <Card key={b.id} title={b.title} subtitle="Failed" accent="red">
               <p className="text-xs text-text-muted">
-                Yea {b.supportVotes} – Nay {b.opposeVotes}
+                Yea {b.supportVotes} &ndash; Nay {b.opposeVotes}
               </p>
             </Card>
           ))}
@@ -135,6 +173,129 @@ export function LegislationPanel(): JSX.Element {
       )}
     </div>
   );
+}
+
+/**
+ * Visual card for an in-flight bill. Split out from the main component so
+ * each card can memoise its progress math without re-rendering neighbours.
+ */
+function PendingBillCard({
+  bill,
+  today,
+  pc,
+  onExpedite,
+  onVote,
+}: {
+  bill: Bill;
+  today: number;
+  pc: number;
+  onExpedite: () => void;
+  onVote: () => void;
+}): JSX.Element {
+  const clocked = (['committee', 'floor_debate', 'vote'] as const).includes(
+    bill.stage as 'committee' | 'floor_debate' | 'vote',
+  );
+
+  // Derive progress numbers. Legacy saves without timers render with a
+  // 0% bar; LegislationSystem.dailyUpdate will seed the timer on the next
+  // tick and progress will appear.
+  const totalDays =
+    bill.stageEnteredOnDay !== undefined && bill.stageEndsOnDay !== undefined
+      ? bill.stageEndsOnDay - bill.stageEnteredOnDay
+      : 0;
+  const elapsed =
+    bill.stageEnteredOnDay !== undefined ? Math.max(0, today - bill.stageEnteredOnDay) : 0;
+  const remaining =
+    bill.stageEndsOnDay !== undefined ? Math.max(0, bill.stageEndsOnDay - today) : 0;
+
+  const forecast = LegislationSystem.estimatePassageChance(bill);
+  const stageKey = bill.stage as keyof typeof EXPEDITE_PC_COST;
+  const pcCost = clocked ? EXPEDITE_PC_COST[stageKey] : 0;
+  const canExpedite = clocked && pc >= pcCost;
+
+  return (
+    <Card title={bill.title} subtitle={stageLabel(bill.stage)} accent="gold">
+      <p className="text-sm text-text-secondary mb-3">{bill.description}</p>
+
+      {clocked && totalDays > 0 && (
+        <div className="mb-3">
+          <Bar
+            value={elapsed}
+            max={totalDays}
+            tone="gold"
+            label={`${stageLabel(bill.stage)} \u00b7 day ${elapsed} of ${totalDays}`}
+            valueLabel={remaining === 0 ? 'ready' : `${remaining} days left`}
+          />
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 text-xs text-text-muted mb-3 flex-wrap">
+        <span className={`px-2 py-0.5 rounded font-mono ${chanceToneClass(forecast)}`}>
+          Forecast: {Math.round(forecast * 100)}%
+        </span>
+        <span>Opposition: {bill.opposition}</span>
+        <span>PC invested: {bill.pcInvested}</span>
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        {bill.stage === 'vote' ? (
+          <Button size="sm" variant="primary" onClick={onVote}>
+            Call the vote now
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={onExpedite}
+            disabled={!canExpedite}
+            title={
+              canExpedite
+                ? `Skip the remaining ${remaining} days by spending ${pcCost} PC.`
+                : `Needs ${pcCost} PC to expedite.`
+            }
+          >
+            Expedite ({pcCost} PC)
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * Maps passage probability to a tone class. Neutral grey in the uncertain
+ * band (30&ndash;70%), success green for a likely pass, danger red for a
+ * likely failure.
+ */
+function chanceToneClass(chance: number): string {
+  if (chance >= 0.7) return 'bg-status-success/20 text-status-success';
+  if (chance <= 0.3) return 'bg-status-danger/20 text-status-danger';
+  return 'bg-bg-tertiary text-text-secondary';
+}
+
+function stageLabel(stage: BillStage): string {
+  switch (stage) {
+    case 'committee':
+      return 'Committee';
+    case 'floor_debate':
+      return 'Floor Debate';
+    case 'vote':
+      return 'Scheduled Vote';
+    case 'draft':
+      return 'Drafting';
+    case 'signed':
+      return 'Signed';
+    case 'vetoed':
+      return 'Vetoed';
+    case 'implementing':
+      return 'Implementing';
+    case 'enacted':
+      return 'Enacted';
+    case 'failed':
+      return 'Failed';
+    default:
+      return stage;
+  }
 }
 
 function TabButton({

--- a/src/systems/LegislationSystem.test.ts
+++ b/src/systems/LegislationSystem.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the April 2026 legislative-pacing pass.
+ *
+ * Covers:
+ *  - `draftBill` places a bill in `committee` with a correctly seeded clock.
+ *  - `dailyUpdate` auto-advances stages when the clock expires, free of PC.
+ *  - `expediteStage` pays PC and jumps forward immediately.
+ *  - `estimatePassageChance` is deterministic and in [0, 1].
+ *
+ * These tests drive the stores directly rather than going through the full
+ * GameEngine bootstrap so they stay fast and focused.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  LegislationSystem,
+  STAGE_DURATION_DAYS,
+  EXPEDITE_PC_COST,
+} from './LegislationSystem';
+import { CongressSystem } from './CongressSystem';
+import { useGameStore } from '@/store/gameStore';
+import { useWorldStore } from '@/store/worldStore';
+import { useCharacterStore } from '@/store/characterStore';
+import { useUIStore } from '@/store/uiStore';
+import { toEpochDays, addDays } from '@/utils/date';
+import type { BillTemplate } from '@/types';
+
+/**
+ * Minimal bill template for tests. Uses the default stage durations so we
+ * can reason about the clock via the shared `STAGE_DURATION_DAYS` constant.
+ */
+const TEMPLATE: BillTemplate = {
+  id: 'test-bill',
+  title: 'Test Bill',
+  description: 'A bill used only for testing.',
+  tags: ['economy'],
+  budgetImpact: 0,
+  pcCost: { committee: 10, floor: 15, vote: 10 },
+  opposition: 30,
+  implementationDays: 30,
+  effects: [],
+  affectedGroups: [],
+};
+
+/**
+ * Resets every store between tests so that a lingering bill from one test
+ * can't pollute another. We also seed Congress so `resolveVote` and
+ * `estimatePassageChance` have a chamber to iterate over.
+ */
+function resetStoresAndSeedCongress(): void {
+  useGameStore.getState().reset();
+  useWorldStore.getState().reset();
+  useCharacterStore.setState((s) => {
+    s.id = 'player';
+    s.stats.strategy = 5;
+  });
+  // Need enough PC for expedite tests.
+  useGameStore.setState((s) => {
+    s.politicalCapital = 100;
+  });
+  // Seat a modest senate so the forecast / vote systems have something to
+  // chew on. 100 senators ≈ realistic count.
+  const { senate, house } = CongressSystem.generate(42, { D: 50, R: 50 });
+  useWorldStore.setState((s) => {
+    s.seed = 42;
+    s.congress.senate = senate;
+    s.congress.house = house;
+  });
+  // Silence toasts during tests.
+  vi.spyOn(useUIStore.getState(), 'pushToast').mockImplementation(() => {});
+  // Register our one test template so the system can look it up for
+  // per-template stage-duration overrides (none used here, but the lookup
+  // itself is exercised on every auto-advance).
+  LegislationSystem.registerTemplates([TEMPLATE]);
+}
+
+describe('LegislationSystem — pacing', () => {
+  beforeEach(() => {
+    resetStoresAndSeedCongress();
+  });
+
+  it('draftBill places the bill in committee with a populated clock', () => {
+    const startDay = toEpochDays(useGameStore.getState().currentDate);
+
+    const bill = LegislationSystem.draftBill(TEMPLATE);
+
+    expect(bill.stage).toBe('committee');
+    expect(bill.stageEnteredOnDay).toBe(startDay);
+    expect(bill.stageEndsOnDay).toBe(startDay + STAGE_DURATION_DAYS.committee);
+  });
+
+  it('dailyUpdate does nothing while the clock has not expired', () => {
+    const bill = LegislationSystem.draftBill(TEMPLATE);
+
+    // Advance 5 days (less than the 21-day committee clock).
+    for (let i = 0; i < 5; i++) useGameStore.getState().advanceDay();
+    LegislationSystem.dailyUpdate();
+
+    const updated = useWorldStore
+      .getState()
+      .pendingLegislation.find((b) => b.id === bill.id);
+    expect(updated?.stage).toBe('committee');
+  });
+
+  it('dailyUpdate auto-advances a bill when its stage clock expires — no PC spent', () => {
+    const pcBefore = useGameStore.getState().politicalCapital;
+    const bill = LegislationSystem.draftBill(TEMPLATE);
+
+    // Advance exactly the full committee duration.
+    for (let i = 0; i < STAGE_DURATION_DAYS.committee; i++) {
+      useGameStore.getState().advanceDay();
+    }
+    LegislationSystem.dailyUpdate();
+
+    const updated = useWorldStore
+      .getState()
+      .pendingLegislation.find((b) => b.id === bill.id);
+    expect(updated?.stage).toBe('floor_debate');
+    // Free advance — no PC paid.
+    expect(useGameStore.getState().politicalCapital).toBe(pcBefore);
+    // New clock seeded for the next stage.
+    const today = toEpochDays(useGameStore.getState().currentDate);
+    expect(updated?.stageEnteredOnDay).toBe(today);
+    expect(updated?.stageEndsOnDay).toBe(today + STAGE_DURATION_DAYS.floor_debate);
+  });
+
+  it('expediteStage charges PC and jumps immediately to the next stage', () => {
+    const bill = LegislationSystem.draftBill(TEMPLATE);
+    const pcBefore = useGameStore.getState().politicalCapital;
+
+    const result = LegislationSystem.expediteStage(bill.id);
+
+    expect(result.ok).toBe(true);
+    expect(result.newStage).toBe('floor_debate');
+    expect(useGameStore.getState().politicalCapital).toBe(
+      pcBefore - EXPEDITE_PC_COST.committee,
+    );
+  });
+
+  it('expediteStage refuses when the player cannot afford the cost', () => {
+    const bill = LegislationSystem.draftBill(TEMPLATE);
+    useGameStore.setState((s) => {
+      s.politicalCapital = 0;
+    });
+
+    const result = LegislationSystem.expediteStage(bill.id);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/insufficient/i);
+    // Bill stayed put.
+    const updated = useWorldStore
+      .getState()
+      .pendingLegislation.find((b) => b.id === bill.id);
+    expect(updated?.stage).toBe('committee');
+  });
+
+  it('estimatePassageChance returns a deterministic probability in [0, 1]', () => {
+    const a = LegislationSystem.estimatePassageChance({
+      tags: ['economy'],
+      opposition: 30,
+    });
+    const b = LegislationSystem.estimatePassageChance({
+      tags: ['economy'],
+      opposition: 30,
+    });
+    expect(a).toBe(b);
+    expect(a).toBeGreaterThanOrEqual(0);
+    expect(a).toBeLessThanOrEqual(1);
+  });
+
+  it('estimatePassageChance penalises opposition', () => {
+    const low = LegislationSystem.estimatePassageChance({ tags: ['economy'], opposition: 10 });
+    const high = LegislationSystem.estimatePassageChance({ tags: ['economy'], opposition: 90 });
+    expect(low).toBeGreaterThan(high);
+  });
+
+  it('dailyUpdate resolves a vote when the vote-stage clock expires', () => {
+    const bill = LegislationSystem.draftBill(TEMPLATE);
+    // Fast-forward through committee and floor_debate via expedite so we
+    // land directly in `vote` without needing 35 sequential daily ticks.
+    LegislationSystem.expediteStage(bill.id); // committee → floor_debate
+    LegislationSystem.expediteStage(bill.id); // floor_debate → vote
+
+    const voteStageBill = useWorldStore
+      .getState()
+      .pendingLegislation.find((b) => b.id === bill.id);
+    expect(voteStageBill?.stage).toBe('vote');
+
+    // Let the 7-day vote clock expire.
+    for (let i = 0; i < STAGE_DURATION_DAYS.vote; i++) {
+      useGameStore.getState().advanceDay();
+    }
+    LegislationSystem.dailyUpdate();
+
+    const finalBill =
+      useWorldStore.getState().passedLegislation.find((b) => b.id === bill.id) ??
+      useWorldStore.getState().failedLegislation.find((b) => b.id === bill.id);
+    expect(finalBill).toBeDefined();
+    expect(['signed', 'failed']).toContain(finalBill!.stage);
+  });
+});
+
+// Silences unused-import warning when addDays isn't reached. Retained in
+// case a future test needs the helper.
+void addDays;

--- a/src/systems/LegislationSystem.ts
+++ b/src/systems/LegislationSystem.ts
@@ -1,40 +1,204 @@
+/**
+ * LegislationSystem — bill lifecycle management.
+ *
+ * Flow: `draft` → `committee` → `floor_debate` → `vote` → `signed`/`failed`.
+ *
+ * The pacing pass (April 2026) introduced a **legislative clock**: each
+ * stage now has a baseline duration in simulated days, and bills naturally
+ * advance through their stages as the in-game calendar ticks. Players may
+ * optionally spend Political Capital to **expedite** the current stage —
+ * paying to skip whatever days remain before the next auto-advance.
+ *
+ * Design intent:
+ *  - TIME is the primary cost. A player who has all the PC in the world
+ *    still cannot ship a bill in a single afternoon; floor time is the gate.
+ *  - PC is an optional accelerator for emergencies or closing moves.
+ *  - While a bill sits in committee / on the floor, the player can work on
+ *    other things (cards, quests, fundraising) — this turns "waiting" into
+ *    productive downtime rather than dead air.
+ *
+ * See `docs/research/pacing-legislative-timeline-2026-04.md` for the full
+ * design rationale, risk analysis, and tuning table.
+ *
+ * @module systems/LegislationSystem
+ */
 import type { Bill, BillTemplate, BillId, BillStage } from '@/types';
 import { useGameStore } from '@/store/gameStore';
 import { useCharacterStore } from '@/store/characterStore';
 import { useWorldStore } from '@/store/worldStore';
+import { useUIStore } from '@/store/uiStore';
 import { applyEffects } from '@/engine/applyEffect';
 import { SeededRNG } from '@/utils/random';
 import { makeId } from '@/utils/id';
 import { clamp } from '@/utils/math';
+import { toEpochDays } from '@/utils/date';
 
 /**
- * LegislationSystem — bill lifecycle management.
+ * Default per-stage duration, in simulated days. Exported so tests and
+ * future design docs can reference the same numbers and so modders can
+ * override per-bill via `BillTemplate.stageDurations`.
  *
- * Flow: draft → committee → floor_debate → vote → signed/vetoed →
- * implementing → enacted | failed.
+ *   committee     — 3 weeks.  Markup, witness hearings, committee vote.
+ *   floor_debate  — 2 weeks.  Floor speeches, motion management, amendments.
+ *   vote          — 1 week.   Roll-call scheduling and the vote itself.
  *
- * Each stage advance consumes political capital and is influenced by the
- * player's Strategy stat plus relationships in the relevant chamber.
+ * Stages without an entry here (`draft`, `signed`, `vetoed`, etc.) are
+ * instantaneous or terminal and skip the clock entirely.
  */
+export const STAGE_DURATION_DAYS: Record<'committee' | 'floor_debate' | 'vote', number> = {
+  committee: 21,
+  floor_debate: 14,
+  vote: 7,
+};
+
+/**
+ * PC cost to expedite a given stage — i.e. to skip *all remaining* days in
+ * the stage and move the bill straight to the next one. Prices are tuned so
+ * that running the clock is the cheap path and expediting is the exception.
+ */
+export const EXPEDITE_PC_COST: Record<'committee' | 'floor_debate' | 'vote', number> = {
+  committee: 25,
+  floor_debate: 20,
+  vote: 15,
+};
+
+/** Ordered stages that have a clock attached. Used for stage transitions. */
+const CLOCKED_STAGES: readonly BillStage[] = ['committee', 'floor_debate', 'vote'] as const;
+
+/** Result shape returned by `expediteStage` — keeps the panel's wiring thin. */
+export interface ExpediteResult {
+  ok: boolean;
+  newStage: BillStage;
+  reason?: string;
+}
+
+/** Result shape returned by `resolveVote`. Unchanged from pre-pacing. */
+export interface VoteResult {
+  passed: boolean;
+  yea: number;
+  nay: number;
+}
+
 export interface LegislationSystemAPI {
+  /** Create a new bill and push it straight into `committee`. */
   draftBill(template: BillTemplate): Bill;
-  advanceStage(billId: BillId): { ok: boolean; newStage: BillStage; reason?: string };
-  resolveVote(billId: BillId): { passed: boolean; yea: number; nay: number };
+  /**
+   * Pay PC to skip the remainder of the current stage's clock. The bill is
+   * advanced to the next stage immediately (or resolved, in the case of
+   * `vote`). If the current stage is not clocked, the expedite is a no-op.
+   */
+  expediteStage(billId: BillId): ExpediteResult;
+  /**
+   * Resolve a floor vote RIGHT NOW. Called both by the player (via the
+   * Legislation panel when the bill is in `vote`) and by `dailyUpdate` when
+   * the vote-stage clock expires with no player action.
+   */
+  resolveVote(billId: BillId): VoteResult;
+  /**
+   * Tick each pending bill forward by one day. If a bill's `stageEndsOnDay`
+   * has been reached or passed, auto-advance it — free of PC cost. This
+   * runs on every `TimeEngine.onDaily` tick.
+   */
+  dailyUpdate(): void;
+  /**
+   * Point-estimate of passage probability in [0, 1], computed by averaging
+   * the per-legislator baseline vote probabilities (the same function used
+   * by `resolveVote`) without invoking any RNG. Used by the UI forecast.
+   */
+  estimatePassageChance(bill: Pick<Bill, 'tags' | 'opposition'>): number;
+  /**
+   * Register the bill-template catalogue. Called by `GameEngine` during
+   * boot; used internally by the system to resolve per-template clock
+   * overrides without a circular module import.
+   */
+  registerTemplates(templates: readonly BillTemplate[]): void;
+  /** @deprecated Kept for backwards compatibility. No longer called anywhere. */
   weeklyUpdate(): void;
 }
 
-const STAGE_ORDER: BillStage[] = ['draft', 'committee', 'floor_debate', 'vote'];
+/**
+ * Looks up the duration (in days) the given bill should spend in the given
+ * stage. Respects per-template overrides and falls back to the default.
+ */
+function durationFor(template: BillTemplate | undefined, stage: BillStage): number {
+  if (!CLOCKED_STAGES.includes(stage)) return 0;
+  const key = stage as keyof typeof STAGE_DURATION_DAYS;
+  const override = template?.stageDurations?.[key];
+  return override ?? STAGE_DURATION_DAYS[key];
+}
+
+/**
+ * Returns the next clocked stage after `stage`. When called on `vote`,
+ * returns `signed` as a sentinel: `dailyUpdate` interprets that as "time to
+ * resolve the vote" rather than "move to a new waiting stage".
+ */
+function nextStageAfter(stage: BillStage): BillStage {
+  switch (stage) {
+    case 'committee':
+      return 'floor_debate';
+    case 'floor_debate':
+      return 'vote';
+    case 'vote':
+      return 'signed'; // sentinel — caller resolves vote before applying
+    default:
+      return stage;
+  }
+}
+
+/**
+ * Averages the per-legislator baseline vote probability. This mirrors the
+ * formula in `resolveVote` but without the RNG draw — it's a *point
+ * estimate*, not a binary outcome. Keeping the formula in one place here
+ * and in `resolveVote` means the player's forecast can never disagree with
+ * the mechanic that actually resolves the vote.
+ */
+function perLegislatorPassChance(args: {
+  alignment: boolean;
+  relationship: number;
+  opposition: number;
+  strategy: number;
+}): number {
+  const alignmentBonus = args.alignment ? 0.3 : 0;
+  const relationshipPush = (args.relationship / 100) * 0.2;
+  const oppositionDrag = (args.opposition / 100) * 0.4;
+  const strategyBoost = (args.strategy / 10) * 0.1;
+  return clamp(0.5 + alignmentBonus + relationshipPush - oppositionDrag + strategyBoost, 0.05, 0.95);
+}
 
 class LegislationSystemImpl implements LegislationSystemAPI {
+  /**
+   * Template catalogue registered at boot by `GameEngine.registerContent`.
+   * Consulted by `findTemplate` to read per-template overrides. Kept as a
+   * plain private field rather than imported dynamically so we do not
+   * depend on Node's `require` or a module-alias cycle.
+   */
+  private templates: BillTemplate[] = [];
+
+  registerTemplates(templates: readonly BillTemplate[]): void {
+    this.templates = [...templates];
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // DRAFT
+  // ─────────────────────────────────────────────────────────────
+
   draftBill(template: BillTemplate): Bill {
     const rng = new SeededRNG(useWorldStore.getState().seed + Date.now());
+    const today = toEpochDays(useGameStore.getState().currentDate);
+
+    // Bills skip the `draft` stage immediately: in this sim, "drafting" is
+    // the act that *introduces* the bill into committee. A user-facing
+    // draft-then-polish flow can be layered on later if desired.
+    const stage: BillStage = 'committee';
+    const committeeDays = durationFor(template, stage);
+
     const bill: Bill = {
       id: makeId('bill', rng) as BillId,
       templateId: template.id,
       title: template.title,
       description: template.description,
       tags: template.tags,
-      stage: 'draft',
+      stage,
       sponsor: useCharacterStore.getState().id || 'player',
       cosponsors: [],
       pcInvested: 0,
@@ -43,40 +207,63 @@ class LegislationSystemImpl implements LegislationSystemAPI {
       opposeVotes: 0,
       createdAt: isoDate(),
       effects: template.effects,
+      stageEnteredOnDay: today,
+      stageEndsOnDay: today + committeeDays,
     };
     useWorldStore.getState().addBill(bill);
     return bill;
   }
 
-  advanceStage(billId: BillId) {
+  // ─────────────────────────────────────────────────────────────
+  // EXPEDITE (player-driven stage advance, costs PC)
+  // ─────────────────────────────────────────────────────────────
+
+  expediteStage(billId: BillId): ExpediteResult {
     const world = useWorldStore.getState();
     const bill = world.pendingLegislation.find((b) => b.id === billId);
-    if (!bill) return { ok: false, newStage: 'failed' as BillStage, reason: 'Bill not found' };
+    if (!bill) return { ok: false, newStage: 'failed', reason: 'Bill not found' };
 
-    const currentIdx = STAGE_ORDER.indexOf(bill.stage);
-    if (currentIdx === -1 || currentIdx === STAGE_ORDER.length - 1) {
-      return { ok: false, newStage: bill.stage, reason: 'Bill already at vote stage' };
+    if (!CLOCKED_STAGES.includes(bill.stage)) {
+      return { ok: false, newStage: bill.stage, reason: 'Stage cannot be expedited' };
     }
-    const nextStage = STAGE_ORDER[currentIdx + 1];
 
-    // PC costs per stage — rough MVP tuning.
-    const costs: Record<BillStage, number> = {
-      draft: 0,
-      committee: 10,
-      floor_debate: 15,
-      vote: 10,
-      signed: 0, vetoed: 0, implementing: 0, enacted: 0, failed: 0,
-    };
-    const pcCost = costs[nextStage];
+    const stageKey = bill.stage as keyof typeof EXPEDITE_PC_COST;
+    const pcCost = EXPEDITE_PC_COST[stageKey];
     const pc = useGameStore.getState().politicalCapital;
-    if (pc < pcCost) return { ok: false, newStage: bill.stage, reason: 'Insufficient political capital' };
+    if (pc < pcCost) {
+      return { ok: false, newStage: bill.stage, reason: 'Insufficient political capital' };
+    }
     useGameStore.getState().addPoliticalCapital(-pcCost);
 
-    world.updateBill(billId, { stage: nextStage, pcInvested: bill.pcInvested + pcCost });
-    return { ok: true, newStage: nextStage };
+    // Special case: expediting the VOTE stage means "call the roll now".
+    // Resolve the vote instead of transitioning to a new waiting stage.
+    if (bill.stage === 'vote') {
+      const result = this.resolveVote(billId);
+      return {
+        ok: true,
+        newStage: result.passed ? 'signed' : 'failed',
+      };
+    }
+
+    // Normal case: advance to the next stage and reset its clock.
+    const template = this.findTemplate(bill.templateId);
+    const next = nextStageAfter(bill.stage);
+    const today = toEpochDays(useGameStore.getState().currentDate);
+    const nextDuration = durationFor(template, next);
+    world.updateBill(billId, {
+      stage: next,
+      pcInvested: bill.pcInvested + pcCost,
+      stageEnteredOnDay: today,
+      stageEndsOnDay: today + nextDuration,
+    });
+    return { ok: true, newStage: next };
   }
 
-  resolveVote(billId: BillId) {
+  // ─────────────────────────────────────────────────────────────
+  // VOTE (resolve a floor vote deterministically against Congress)
+  // ─────────────────────────────────────────────────────────────
+
+  resolveVote(billId: BillId): VoteResult {
     const world = useWorldStore.getState();
     const bill = world.pendingLegislation.find((b) => b.id === billId);
     if (!bill) return { passed: false, yea: 0, nay: 0 };
@@ -87,16 +274,14 @@ class LegislationSystemImpl implements LegislationSystemAPI {
 
     let yea = 0;
     let nay = 0;
-
     for (const legis of senate) {
-      const alignment = legis.priorities.some((p) => bill.tags.includes(p)) ? 0.3 : 0;
-      const relationshipPush = (legis.relationship / 100) * 0.2;
-      const partyBias = legis.party === 'D' ? 0 : 0; // neutral in MVP
-      const opposition = (bill.opposition / 100) * 0.4;
-      const strategyBoost = (strategy / 10) * 0.1;
-      const baseChance = clamp(0.5 + alignment + relationshipPush + partyBias - opposition + strategyBoost, 0.05, 0.95);
-
-      if (rng.next() < baseChance) yea++;
+      const p = perLegislatorPassChance({
+        alignment: legis.priorities.some((pri) => bill.tags.includes(pri)),
+        relationship: legis.relationship,
+        opposition: bill.opposition,
+        strategy,
+      });
+      if (rng.next() < p) yea++;
       else nay++;
     }
 
@@ -106,19 +291,126 @@ class LegislationSystemImpl implements LegislationSystemAPI {
       supportVotes: yea,
       opposeVotes: nay,
     });
-
     if (passed) {
       applyEffects(bill.effects);
       world.movePending(billId, 'passed');
     } else {
       world.movePending(billId, 'failed');
     }
-
     return { passed, yea, nay };
   }
 
+  // ─────────────────────────────────────────────────────────────
+  // DAILY TICK (auto-advance stages whose clocks have expired)
+  // ─────────────────────────────────────────────────────────────
+
+  dailyUpdate(): void {
+    const world = useWorldStore.getState();
+    const today = toEpochDays(useGameStore.getState().currentDate);
+    const pushToast = useUIStore.getState().pushToast;
+
+    // Iterate over a snapshot so `movePending` calls inside resolveVote don't
+    // interfere with the loop.
+    for (const bill of [...world.pendingLegislation]) {
+      if (!CLOCKED_STAGES.includes(bill.stage)) continue;
+
+      // A legacy save may have no timer at all — seed one on first sight so
+      // the bill still progresses under the new rules.
+      if (bill.stageEndsOnDay === undefined) {
+        const template = this.findTemplate(bill.templateId);
+        const duration = durationFor(template, bill.stage);
+        world.updateBill(bill.id, {
+          stageEnteredOnDay: today,
+          stageEndsOnDay: today + duration,
+        });
+        continue;
+      }
+
+      if (today < bill.stageEndsOnDay) continue; // still in progress
+
+      // Clock expired. Transition naturally — no PC cost on a natural
+      // advance; time is the toll.
+      if (bill.stage === 'vote') {
+        const result = this.resolveVote(bill.id);
+        pushToast({
+          message: result.passed
+            ? `${bill.title} PASSED ${result.yea}–${result.nay}`
+            : `${bill.title} FAILED ${result.yea}–${result.nay}`,
+          severity: result.passed ? 'success' : 'danger',
+          ttl: 5000,
+        });
+        continue;
+      }
+
+      const template = this.findTemplate(bill.templateId);
+      const next = nextStageAfter(bill.stage);
+      const duration = durationFor(template, next);
+      world.updateBill(bill.id, {
+        stage: next,
+        stageEnteredOnDay: today,
+        stageEndsOnDay: today + duration,
+      });
+      pushToast({
+        message: `${bill.title} → ${humanStage(next)}`,
+        severity: 'info',
+        ttl: 3000,
+      });
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // FORECAST (no RNG; used by the UI)
+  // ─────────────────────────────────────────────────────────────
+
+  estimatePassageChance(bill: Pick<Bill, 'tags' | 'opposition'>): number {
+    const world = useWorldStore.getState();
+    const senate = world.congress.senate;
+    if (senate.length === 0) return 0;
+    const strategy = useCharacterStore.getState().stats.strategy;
+
+    // Sum per-legislator probabilities; divide by chamber size. This is a
+    // linear approximation of the pass rate — adequate for UI guidance,
+    // cheap to compute on every render.
+    let total = 0;
+    for (const legis of senate) {
+      total += perLegislatorPassChance({
+        alignment: legis.priorities.some((pri) => bill.tags.includes(pri)),
+        relationship: legis.relationship,
+        opposition: bill.opposition,
+        strategy,
+      });
+    }
+    return total / senate.length;
+  }
+
   weeklyUpdate(): void {
-    // Future: decay opposition when player builds support, etc.
+    // No-op. Retained for interface compatibility with GameEngine bootstrap.
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // INTERNAL HELPERS
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Resolves a bill's template by id from the in-memory catalogue that
+   * `GameEngine` registered at boot.
+   */
+  private findTemplate(templateId: string): BillTemplate | undefined {
+    return this.templates.find((t) => t.id === templateId);
+  }
+}
+
+/** Human-readable stage label for toasts. */
+function humanStage(stage: BillStage): string {
+  switch (stage) {
+    case 'committee':
+      return 'Committee';
+    case 'floor_debate':
+      return 'Floor Debate';
+    case 'vote':
+      return 'Scheduled for vote';
+    default:
+      return stage;
   }
 }
 

--- a/src/types/legislation.ts
+++ b/src/types/legislation.ts
@@ -41,6 +41,14 @@ export interface BillTemplate {
   opposition: number;
   /** Days until effects manifest after enactment. */
   implementationDays: number;
+  /**
+   * Optional per-stage duration override (in simulated days).
+   *
+   * When omitted, defaults defined in `LegislationSystem.STAGE_DURATION_DAYS`
+   * apply. Use this field to slow down constitutional amendments or speed up
+   * emergency appropriations at the template level without touching code.
+   */
+  stageDurations?: Partial<Record<'committee' | 'floor_debate' | 'vote', number>>;
   /** Effects applied when the bill is enacted. */
   effects: Effect[];
   /** Population groups primarily affected (for UI highlights). */
@@ -64,4 +72,20 @@ export interface Bill {
   createdAt: string;
   enactedAt?: string;
   effects: Effect[];
+  /**
+   * Monotonic day counter (via `toEpochDays`) on which the bill entered its
+   * current stage. Used together with the per-stage duration to compute how
+   * many days remain before auto-advancement on the next daily tick.
+   *
+   * Legacy saves that predate the pacing pass will be missing this field;
+   * the system treats an undefined value as "just entered this stage on the
+   * day the save was loaded".
+   */
+  stageEnteredOnDay?: number;
+  /**
+   * Monotonic day counter at which the current stage auto-advances. Bills
+   * in stages that have no clock (`draft`, `signed`, `failed`, etc.) carry
+   * this as 0 / undefined.
+   */
+  stageEndsOnDay?: number;
 }


### PR DESCRIPTION
## Summary
Legislative pacing pass: bills now march through committee (21d) -> floor_debate (14d) -> vote (7d) on an in-game clock. Time is the primary cost; Political Capital becomes an optional accelerator.

## What changed
- **Types** (src/types/legislation.ts): new `stageEnteredOnDay`/`stageEndsOnDay` on `Bill`; optional `stageDurations` on `BillTemplate` for per-bill overrides.
- **System** (src/systems/LegislationSystem.ts):
  - `draftBill` now places bills directly into committee with a seeded clock.
  - `advanceStage` renamed to `expediteStage`. Costs 25/20/15 PC to skip the remaining days of committee/floor/vote.
  - New `dailyUpdate` hook auto-advances stages when their clock expires (free of PC; time is the toll).
  - New `estimatePassageChance` — deterministic point estimate used by the UI forecast.
  - New `registerTemplates` pattern replaces a circular GameEngine dependency.
- **Engine** (src/engine/GameEngine.ts): wires `LegislationSystem.dailyUpdate` into the daily tick and registers bill templates at boot.
- **UI** (src/renderer/panels/LegislationPanel.tsx): rebuilt with progress bars, days-remaining, passage-chance badges, and Expedite buttons. Draft list is now ranked by forecast.

## Testing
- Typecheck: clean (`npm run typecheck`)
- Lint: clean (`npm run lint`)
- Unit tests: **89/89** passing, including a new 8-test pacing suite (`src/systems/LegislationSystem.test.ts`) covering auto-advance, expedite PC gating, and deterministic forecast.
- Playwright infrastructure is not yet wired in this repo (`test:e2e` script absent); visual spot-check via `npm run dev` — landing/character-creation render correctly against the new panel.

## Docs
- New: docs/research/pacing-legislative-timeline-2026-04.md (design rationale, tuning table, risks).

## Rollback
Safe to revert; no data-shape breaking changes (legacy bills without timers are re-seeded on first `dailyUpdate`).