### PR TITLE
feat(ui,tooltip): auto-link glossary terms + hold-to-lock tooltips

### DIFF
--- a/docs/about/CHANGELOG.md
+++ b/docs/about/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Political Ascent are recorded here.
 ## [Unreleased]
 
 ### Added
+- **Auto-tooltip terms + hold-to-lock** (`exp--auto-tooltip-terms`).
+  - `<TermText text="..." />` (`src/renderer/components/tooltip/TermText.tsx`) auto-links any registered glossary surface (title or alias) found in plain prose, eliminating the need to wrap each term manually.
+  - Glossary matcher (`registry.ts → findTermMatches`): longest-first preference, non-overlapping ranges, unicode word-boundary regex, lazy compiled-pattern cache invalidated on `registerTooltip` / `clearTooltips`. 11 new Vitest cases.
+  - `TooltipContent.aliases?: string[]` lets terms match shorthand surfaces like "PC" → Political Capital, "AP" → Action Points.
+  - Glossary expanded with 16 new terms covering legislation (`bill`, `committee`, `floor-vote`, `whip`, `veto`), population (`cohort`, `radicalism`, `approval`, `turnout`), economy (`gdp`, `unemployment`, `deficit`), and structural concepts (`scandal`, `quest`, `event`, `scenario`). Every existing entry gained aliases.
+  - `<TermText>` wired into `CardFace` (description + flavour), `DashboardPanel` (news body), `LegislationPanel` (template + bill descriptions), and `QuestsPanel` (quest descriptions). Auto-linking is one prop away for any future panel.
+  - **Hold-to-lock**: `ExtendedTooltip` gained an `lockHoldMs` prop (default 1200ms). Hovering a term shows a gold radial progress arc in the tooltip's top-right corner; when the arc completes, the tooltip auto-pins. Outside-click (capture-phase `pointerdown`) closes a pinned tooltip; `Esc` still works. Footer text updates to reflect mode ("Hold to lock · Shift to pin now" → "Click outside or press Esc to close").
+  - 3 new Playwright tests (`tests/e2e/auto-tooltip.spec.ts`) verifying radial-then-lock, outside-click-close, and Escape-close across `1280×720`, `1440×900`, `1920×1080`.
+
+### Added (previous unreleased)
 - **Card rarity, pack-opening, and stats system** (`exp--cards-and-tooltips`).
   - `CardRarity` union (`common | uncommon | rare | epic | legendary | prismatic`) with deterministic seeded distribution per pack template (`src/engine/cardPackEngine.ts`, 10 unit tests).
   - Optional `stats` block on `CardDefinition`: `power`, `cooldownWeeks`, `usesPerGame`, `level`, `factionAffinity`, `factionBonusMultiplier`. Backwards compatible — legacy cards continue to load.

--- a/src/renderer/components/CardFace.tsx
+++ b/src/renderer/components/CardFace.tsx
@@ -16,7 +16,7 @@
 import { memo } from 'react';
 import type { CardDefinition, CardRarity, CardType } from '@/types';
 import { Icon, type IconName } from './Icon';
-import { ExtendedTooltip, type TooltipContent } from './tooltip';
+import { ExtendedTooltip, TermText, type TooltipContent } from './tooltip';
 
 export interface CardFaceProps {
   def: CardDefinition;
@@ -162,9 +162,9 @@ function CardFaceImpl({
           </div>
         </header>
 
-        {/* Body: description */}
+        {/* Body: description — auto-link any glossary terms in the prose. */}
         <p className={(compact ? 'text-xs' : 'text-sm') + ' text-text-secondary leading-snug'}>
-          {def.description}
+          <TermText text={def.description} />
         </p>
 
         {/* Stats strip */}
@@ -176,10 +176,10 @@ function CardFaceImpl({
           </div>
         )}
 
-        {/* Flavor */}
+        {/* Flavor — auto-link glossary terms inside the in-character quote. */}
         {def.flavorText && !compact && (
           <p className="text-[0.6875rem] italic text-text-muted font-flavor border-t border-rule pt-2 mt-auto">
-            &ldquo;{def.flavorText}&rdquo;
+            &ldquo;<TermText text={def.flavorText} />&rdquo;
           </p>
         )}
 

--- a/src/renderer/components/tooltip/ExtendedTooltip.tsx
+++ b/src/renderer/components/tooltip/ExtendedTooltip.tsx
@@ -50,6 +50,13 @@ export interface ExtendedTooltipProps {
   /** Delay before the tooltip appears, in ms. Default 350. */
   openDelay?: number;
   /**
+   * How long the player must hover before the tooltip auto-locks (in
+   * ms). A radial progress arc fills during the hold. Set to 0 to
+   * disable hold-to-lock; the tooltip then only locks on Shift-leave
+   * (legacy behaviour). Default 1200ms.
+   */
+  lockHoldMs?: number;
+  /**
    * Children must accept `onMouseEnter`, `onMouseLeave`, `onFocus`,
    * `onBlur`. The component clones the child to attach handlers — most
    * built-in elements work. Pass a single React element.
@@ -66,14 +73,24 @@ export interface ExtendedTooltipProps {
  *   </ExtendedTooltip>
  */
 export function ExtendedTooltip(props: ExtendedTooltipProps): JSX.Element {
-  const { term, content, openDelay = 350, children } = props;
+  const { term, content, openDelay = 350, lockHoldMs = 1200, children } = props;
 
   const [open, setOpen] = useState(false);
   const [pinned, setPinned] = useState(false);
+  /**
+   * 0–1 progress of the hover-hold timer. While > 0 and < 1, the card
+   * renders a radial progress arc in its corner. Reaches 1 → the
+   * tooltip auto-pins.
+   */
+  const [holdProgress, setHoldProgress] = useState(0);
   const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
 
   const triggerRef = useRef<HTMLElement | null>(null);
   const timerRef = useRef<number | null>(null);
+  /** rAF handle for the hold-progress animation loop. */
+  const holdRafRef = useRef<number | null>(null);
+  /** Timestamp (performance.now) when the current hold started. */
+  const holdStartRef = useRef<number | null>(null);
   const tooltipId = useId();
 
   const resolved: TooltipContent | undefined = useMemo(() => {
@@ -103,6 +120,48 @@ export function ExtendedTooltip(props: ExtendedTooltipProps): JSX.Element {
     }, openDelay);
   }, [openDelay, positionTooltip]);
 
+  /**
+   * Cancel any in-flight hold animation and reset the progress arc.
+   * Called on mouse-leave (when not pinning) and on close.
+   */
+  const cancelHold = useCallback(() => {
+    if (holdRafRef.current != null) {
+      cancelAnimationFrame(holdRafRef.current);
+      holdRafRef.current = null;
+    }
+    holdStartRef.current = null;
+    setHoldProgress(0);
+  }, []);
+
+  /**
+   * Start (or restart) the hover-hold timer. Drives the radial progress
+   * via rAF so the arc animates smoothly without re-render thrash; once
+   * it reaches 100%, flip `pinned=true` and stop the loop.
+   *
+   * Bypassed entirely when `lockHoldMs <= 0`.
+   */
+  const startHold = useCallback(() => {
+    if (lockHoldMs <= 0) return;
+    cancelHold();
+    holdStartRef.current = performance.now();
+    const tick = (): void => {
+      const start = holdStartRef.current;
+      if (start == null) return;
+      const elapsed = performance.now() - start;
+      const p = Math.min(1, elapsed / lockHoldMs);
+      setHoldProgress(p);
+      if (p >= 1) {
+        // Lock the tooltip and stop the loop.
+        setPinned(true);
+        holdRafRef.current = null;
+        holdStartRef.current = null;
+        return;
+      }
+      holdRafRef.current = requestAnimationFrame(tick);
+    };
+    holdRafRef.current = requestAnimationFrame(tick);
+  }, [lockHoldMs, cancelHold]);
+
   const cancelOpen = useCallback(() => {
     if (timerRef.current != null) {
       window.clearTimeout(timerRef.current);
@@ -112,9 +171,26 @@ export function ExtendedTooltip(props: ExtendedTooltipProps): JSX.Element {
 
   const close = useCallback(() => {
     cancelOpen();
+    cancelHold();
     setOpen(false);
     setPinned(false);
-  }, [cancelOpen]);
+  }, [cancelOpen, cancelHold]);
+
+  // Outside-click closes a pinned tooltip. The tooltip card sets
+  // `pointerEvents:auto` only when pinned, so clicks inside it are
+  // delivered to the card (and don't reach window).
+  useEffect(() => {
+    if (!open || !pinned) return;
+    function onPointerDown(e: PointerEvent): void {
+      const target = e.target as Node | null;
+      if (target && triggerRef.current?.contains(target)) return;
+      // The tooltip element itself stops propagation in TooltipCard,
+      // so anything that bubbles up here is genuinely "outside".
+      close();
+    }
+    window.addEventListener('pointerdown', onPointerDown, true);
+    return () => window.removeEventListener('pointerdown', onPointerDown, true);
+  }, [open, pinned, close]);
 
   // Keyboard: Esc closes a pinned tooltip and returns focus.
   useEffect(() => {
@@ -129,21 +205,29 @@ export function ExtendedTooltip(props: ExtendedTooltipProps): JSX.Element {
     return () => window.removeEventListener('keydown', onKey);
   }, [open, close]);
 
-  // Pin while shift is held during mouse-leave: stays open.
+  // Pin while shift is held during mouse-leave: stays open. Otherwise
+  // close (and abort any in-flight hold animation).
   const handleLeave = useCallback(
     (e: React.MouseEvent | React.FocusEvent) => {
       const shift = (e as React.MouseEvent).shiftKey;
       if (shift) {
+        cancelHold();
         setPinned(true);
         return;
       }
-      if (!pinned) close();
+      if (!pinned) {
+        cancelHold();
+        close();
+      }
     },
-    [pinned, close],
+    [pinned, close, cancelHold],
   );
 
   // Clean up on unmount.
-  useEffect(() => () => cancelOpen(), [cancelOpen]);
+  useEffect(() => () => {
+    cancelOpen();
+    cancelHold();
+  }, [cancelOpen, cancelHold]);
 
   // Clone trigger to attach handlers.
   if (!isValidElement(children)) {
@@ -160,6 +244,7 @@ export function ExtendedTooltip(props: ExtendedTooltipProps): JSX.Element {
     },
     onMouseEnter: (e: React.MouseEvent) => {
       scheduleOpen();
+      startHold();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (children.props as any).onMouseEnter?.(e);
     },
@@ -170,6 +255,7 @@ export function ExtendedTooltip(props: ExtendedTooltipProps): JSX.Element {
     },
     onFocus: (e: React.FocusEvent) => {
       scheduleOpen();
+      startHold();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (children.props as any).onFocus?.(e);
     },
@@ -191,6 +277,7 @@ export function ExtendedTooltip(props: ExtendedTooltipProps): JSX.Element {
             content={resolved}
             coords={coords}
             pinned={pinned}
+            holdProgress={holdProgress}
             onClose={close}
           />,
           document.body,
@@ -208,11 +295,13 @@ interface TooltipCardProps {
   content: TooltipContent;
   coords: { top: number; left: number };
   pinned: boolean;
+  /** 0–1 hover-hold progress; renders the corner arc when 0 < p < 1. */
+  holdProgress: number;
   onClose: () => void;
 }
 
 function TooltipCard(props: TooltipCardProps): JSX.Element {
-  const { id, content, coords, pinned, onClose } = props;
+  const { id, content, coords, pinned, holdProgress, onClose } = props;
   const ref = useRef<HTMLDivElement | null>(null);
   const [adjusted, setAdjusted] = useState<CSSProperties | null>(null);
 
@@ -230,11 +319,21 @@ function TooltipCard(props: TooltipCardProps): JSX.Element {
     setAdjusted({ top, left });
   }, [coords]);
 
+  // The radial appears only while we are still actively holding (i.e.
+  // not yet pinned and progress is between epsilon and 1). At p=1 the
+  // parent has already pinned the tooltip and stopped feeding progress.
+  const showHoldRing = !pinned && holdProgress > 0.02 && holdProgress < 1;
+
   return (
     <div
       ref={ref}
       id={id}
       role="tooltip"
+      onPointerDown={(e) => {
+        // Stop pointerdown inside the (pinned) card from bubbling to
+        // the window-level outside-click handler that would close us.
+        if (pinned) e.stopPropagation();
+      }}
       style={{
         position: 'fixed',
         top: adjusted?.top ?? coords.top,
@@ -247,6 +346,7 @@ function TooltipCard(props: TooltipCardProps): JSX.Element {
       }}
       className="bg-bg-secondary border border-rule-strong rounded-sm shadow-glow-gold animate-tooltip-enter"
     >
+      {showHoldRing && <HoldRing progress={holdProgress} />}
       <header className="flex items-start gap-2 px-3 py-2 border-b border-rule">
         {content.icon && (
           <Icon name={content.icon as IconName} size={16} className="text-accent-gold mt-0.5 shrink-0" />
@@ -294,11 +394,56 @@ function TooltipCard(props: TooltipCardProps): JSX.Element {
 
         {!pinned && (
           <p className="font-mono text-[0.625rem] tracking-wider text-text-muted opacity-70 pt-1">
-            Hold <kbd className="px-1 border border-rule rounded-sm">Shift</kbd> to pin
+            Hold to lock · <kbd className="px-1 border border-rule rounded-sm">Shift</kbd> to pin now
+          </p>
+        )}
+        {pinned && (
+          <p className="font-mono text-[0.625rem] tracking-wider text-text-muted opacity-70 pt-1">
+            Click outside or press <kbd className="px-1 border border-rule rounded-sm">Esc</kbd> to close
           </p>
         )}
       </div>
     </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// HOLD RING — radial progress shown in the tooltip's top-right corner
+// while the player is hover-holding to lock. Pure SVG, no animations
+// library: we re-render at 60Hz only while the hold is active, which
+// is bounded to ~1–2 seconds total.
+// ─────────────────────────────────────────────────────────────
+
+function HoldRing({ progress }: { progress: number }): JSX.Element {
+  // 14px radius, 2px stroke; circumference ≈ 87.96.
+  const r = 7;
+  const c = 2 * Math.PI * r;
+  const offset = c * (1 - progress);
+  return (
+    <svg
+      aria-hidden="true"
+      width={20}
+      height={20}
+      viewBox="0 0 20 20"
+      className="absolute top-1.5 right-1.5 pointer-events-none"
+    >
+      {/* Track */}
+      <circle cx={10} cy={10} r={r} fill="none" stroke="rgba(255,255,255,0.12)" strokeWidth={2} />
+      {/* Progress arc — starts at the top (−90deg rotation) and sweeps clockwise. */}
+      <circle
+        cx={10}
+        cy={10}
+        r={r}
+        fill="none"
+        stroke="var(--pa-accent-gold, #c9a84c)"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeDasharray={c}
+        strokeDashoffset={offset}
+        transform="rotate(-90 10 10)"
+        style={{ transition: 'stroke-dashoffset 60ms linear' }}
+      />
+    </svg>
   );
 }
 

--- a/src/renderer/components/tooltip/TermText.tsx
+++ b/src/renderer/components/tooltip/TermText.tsx
@@ -1,0 +1,86 @@
+/**
+ * TermText — auto-link any registered glossary term in plain prose.
+ *
+ * What it solves:
+ *   The original tooltip system required call sites to wrap each term
+ *   manually with `<Term term="…" />` or embed `[term:…]` markers in
+ *   strings. That gets old fast across hundreds of card descriptions,
+ *   bill summaries, quest blurbs, and event copy. `TermText` accepts
+ *   plain prose and inlines a `<Term>` for every registered surface
+ *   (title or alias) it can find, leaving non-matching text untouched.
+ *
+ * How it works:
+ *   {@link findTermMatches} returns non-overlapping match offsets in
+ *   document order. We splice those into a React node array, wrapping
+ *   matched ranges in `<Term>` (which itself uses `<ExtendedTooltip>`),
+ *   and render the rest as bare strings.
+ *
+ * What it deliberately does NOT do:
+ *   - Walk into nested React children. Pass plain strings only — if
+ *     you have markup, decompose it at the call site.
+ *   - Match across HTML elements. The matcher is text-only.
+ *   - Modify casing. Surface text is preserved verbatim.
+ *
+ * @module renderer/tooltip/TermText
+ */
+import { Fragment, type ReactNode } from 'react';
+import { Term } from './ExtendedTooltip';
+import { findTermMatches } from './registry';
+
+export interface TermTextProps {
+  /** The prose to scan. Strings only — pre-render any nested markup. */
+  text: string;
+  /**
+   * Optional list of term ids to *exclude* from auto-linking. Useful
+   * when the surface text is also the heading right above it (avoids
+   * "Political Capital → Political Capital" tautologies).
+   */
+  exclude?: readonly string[];
+  /**
+   * Optional cap on the number of auto-links emitted. Default 8 — past
+   * that, text starts to look like a link farm. The first N matches in
+   * document order win.
+   */
+  limit?: number;
+}
+
+/**
+ * Render `text` with any registered term surfaces auto-linked.
+ *
+ * @example
+ *   <TermText text="Spend PC to whip a vote in committee." />
+ *   // PC and committee become tooltip links; rest is plain.
+ */
+export function TermText({ text, exclude, limit = 8 }: TermTextProps): JSX.Element {
+  if (!text) return <></>;
+  const excludeSet = new Set(exclude ?? []);
+  // Find all candidate matches and drop excluded ids.
+  const matches = findTermMatches(text)
+    .filter((m) => !excludeSet.has(m.id))
+    .slice(0, limit);
+
+  if (matches.length === 0) return <>{text}</>;
+
+  // Splice the matches into a node array.
+  const out: ReactNode[] = [];
+  let cursor = 0;
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i];
+    if (m.start > cursor) out.push(text.slice(cursor, m.start));
+    out.push(
+      <Term key={`${m.id}-${m.start}`} term={m.id}>
+        {m.surface}
+      </Term>,
+    );
+    cursor = m.end;
+  }
+  if (cursor < text.length) out.push(text.slice(cursor));
+
+  return (
+    <>
+      {out.map((node, i) => (
+        <Fragment key={i}>{node}</Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/renderer/components/tooltip/glossary.ts
+++ b/src/renderer/components/tooltip/glossary.ts
@@ -45,6 +45,7 @@ registerTooltip(
       },
     ],
     seeAlso: ['action-points', 'integrity'],
+    aliases: ['PC', 'political capital'],
   },
   {
     id: 'action-points',
@@ -71,6 +72,7 @@ registerTooltip(
       },
     ],
     seeAlso: ['political-capital', 'stat-stamina'],
+    aliases: ['AP', 'action points'],
   },
 
   // ─────────────── Core stats ───────────────
@@ -90,6 +92,7 @@ registerTooltip(
       },
     ],
     seeAlso: ['stat-strategy', 'stat-integrity'],
+    aliases: ['Charisma'],
   },
   {
     id: 'stat-strategy',
@@ -106,6 +109,7 @@ registerTooltip(
       },
     ],
     seeAlso: ['stat-connections', 'political-capital'],
+    aliases: ['Strategy'],
   },
   {
     id: 'stat-connections',
@@ -120,6 +124,7 @@ registerTooltip(
           'mechanics. Veteran characters start with a bonus.',
       },
     ],
+    aliases: ['Connections'],
   },
   {
     id: 'stat-integrity',
@@ -134,6 +139,7 @@ registerTooltip(
           'voter base. Dark cards and shady dialogue choices cost Integrity.',
       },
     ],
+    aliases: ['Integrity'],
   },
   {
     id: 'stat-stamina',
@@ -149,6 +155,7 @@ registerTooltip(
       },
     ],
     seeAlso: ['action-points'],
+    aliases: ['Stamina'],
   },
 
   // ─────────────── Card system ───────────────
@@ -211,5 +218,286 @@ registerTooltip(
           'and unlocks faction-only events and quests.',
       },
     ],
+    aliases: ['faction', 'factions'],
+  },
+
+  // ─────────────── Legislation ───────────────
+  {
+    id: 'bill',
+    title: 'Bill',
+    subtitle: 'Legislation',
+    icon: 'legislation',
+    summary: 'A draft law moving through the legislative pipeline.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'A bill enters as a draft, passes through committee review, then ' +
+          'reaches a floor vote. Each stage exposes different actions: ' +
+          'amendments, hearings, whipping, and floor speeches.',
+      },
+      {
+        kind: 'list',
+        heading: 'Stages',
+        items: ['Drafted', 'Committee', 'Floor', 'Reconciled', 'Passed', 'Vetoed'],
+      },
+    ],
+    seeAlso: ['committee', 'whip', 'floor-vote'],
+    aliases: ['bill', 'bills', 'legislation'],
+  },
+  {
+    id: 'committee',
+    title: 'Committee',
+    subtitle: 'Legislation',
+    icon: 'congress',
+    summary: 'A subset of legislators who review a bill before the floor.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Committees mark up a bill, hold hearings, and decide whether to ' +
+          'forward it. Killing a bill in committee is the cheapest way to ' +
+          'stop it. Hostile chairs are the most common cause of dead bills.',
+      },
+    ],
+    seeAlso: ['bill', 'floor-vote'],
+    aliases: ['committee', 'committees'],
+  },
+  {
+    id: 'floor-vote',
+    title: 'Floor Vote',
+    subtitle: 'Legislation',
+    icon: 'congress',
+    summary: 'The chamber-wide roll call that decides a bill’s fate.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'When a bill clears committee it heads to a floor vote. The ' +
+          'predicted margin updates live as you whip; whips spend [term:political-capital]PC[/] ' +
+          'to nudge specific legislators.',
+      },
+    ],
+    seeAlso: ['whip', 'bill'],
+    aliases: ['floor vote', 'roll call'],
+  },
+  {
+    id: 'whip',
+    title: 'Whip',
+    subtitle: 'Action',
+    icon: 'congress',
+    summary: 'Spend PC to shift a specific vote on a specific bill.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'A whip targets one legislator and one bill. The PC cost scales ' +
+          'with how far you’re asking them to move from their natural ' +
+          'inclination. Repeated whips on the same target suffer ' +
+          'diminishing returns.',
+      },
+    ],
+    seeAlso: ['floor-vote', 'political-capital'],
+    aliases: ['whip', 'whipping'],
+  },
+  {
+    id: 'veto',
+    title: 'Veto',
+    subtitle: 'Legislation',
+    summary: 'An executive rejection of a passed bill.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'A vetoed bill returns to the chamber for a possible override ' +
+          'vote, which requires a higher threshold than the original pass.',
+      },
+    ],
+    aliases: ['veto', 'vetoed'],
+  },
+
+  // ─────────────── Population ───────────────
+  {
+    id: 'cohort',
+    title: 'Cohort',
+    subtitle: 'Population',
+    icon: 'population',
+    summary: 'An intersectional slice of the electorate the sim tracks.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Cohorts are defined by region, class, age, education, and ' +
+          'baseline ideology. Every event, bill, and action moves cohorts ' +
+          'instead of “the public” as a single mass.',
+      },
+    ],
+    seeAlso: ['radicalism', 'approval'],
+    aliases: ['cohort', 'cohorts'],
+  },
+  {
+    id: 'radicalism',
+    title: 'Radicalism',
+    subtitle: 'Population',
+    summary: 'A cohort’s propensity to leave normal politics.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Radicalism rises with grievance, repression, and economic ' +
+          'shock. Cohorts above ~40% radicalism gate extremist events; ' +
+          'cohorts above ~70% are recruitable by movements.',
+      },
+    ],
+    seeAlso: ['cohort'],
+    aliases: ['radicalism', 'radicalised'],
+  },
+  {
+    id: 'approval',
+    title: 'Approval',
+    subtitle: 'Population',
+    summary: 'How well the public thinks you are doing your job.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Approval is a weighted average across [term:cohort]cohorts[/]. ' +
+          'High approval cushions scandals and lowers PC costs on whips.',
+      },
+    ],
+    seeAlso: ['cohort', 'political-capital'],
+    aliases: ['approval', 'approval rating'],
+  },
+  {
+    id: 'turnout',
+    title: 'Turnout',
+    subtitle: 'Population',
+    summary: 'The share of a cohort that actually votes.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Turnout multiplies a cohort’s political weight. A small but ' +
+          'highly engaged cohort can outvote a larger apathetic one.',
+      },
+    ],
+    aliases: ['turnout'],
+  },
+
+  // ─────────────── Economy & misc ───────────────
+  {
+    id: 'gdp',
+    title: 'GDP',
+    subtitle: 'Economy',
+    icon: 'economy',
+    summary: 'Gross Domestic Product — the size of the economy.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'GDP is the headline economic indicator. Growth boosts incumbent ' +
+          'approval; contractions punish it. Sectors update GDP each ' +
+          'monthly tick from population, productivity, and investment.',
+      },
+    ],
+    aliases: ['GDP', 'gross domestic product'],
+  },
+  {
+    id: 'unemployment',
+    title: 'Unemployment',
+    subtitle: 'Economy',
+    summary: 'Share of the labour force without work.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Persistently high unemployment raises [term:radicalism]radicalism[/] ' +
+          'in working-class cohorts and erodes incumbent approval.',
+      },
+    ],
+    seeAlso: ['radicalism'],
+    aliases: ['unemployment'],
+  },
+  {
+    id: 'deficit',
+    title: 'Deficit',
+    subtitle: 'Economy',
+    summary: 'How much the government is overspending this year.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'The deficit is government spending minus revenue. Persistent ' +
+          'deficits accumulate as debt and constrain future spending.',
+      },
+    ],
+    aliases: ['deficit'],
+  },
+  {
+    id: 'scandal',
+    title: 'Scandal',
+    subtitle: 'Event',
+    icon: 'alert',
+    summary: 'A negative event with prolonged approval drag.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Scandals depress [term:approval]approval[/] and bleed PC over ' +
+          'multiple weeks. High [term:stat-integrity]Integrity[/] limits ' +
+          'their severity.',
+      },
+    ],
+    aliases: ['scandal', 'scandals'],
+  },
+  {
+    id: 'quest',
+    title: 'Quest',
+    subtitle: 'Mechanic',
+    icon: 'quests',
+    summary: 'A multi-step storyline with rewards on completion.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Quests give the campaign narrative spine: cause-and-effect ' +
+          'over many weeks, with branching choices and hard-to-reverse ' +
+          'consequences.',
+      },
+    ],
+    aliases: ['quest', 'quests'],
+  },
+  {
+    id: 'event',
+    title: 'Event',
+    subtitle: 'Mechanic',
+    icon: 'alert',
+    summary: 'A timed prompt with two-or-more choices and consequences.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'Events fire when their conditions are met. Many are one-off; ' +
+          'some chain into [term:quest]quests[/]. Ignoring an event is ' +
+          'usually itself a choice.',
+      },
+    ],
+    aliases: ['event', 'events'],
+  },
+  {
+    id: 'scenario',
+    title: 'Scenario',
+    subtitle: 'Concept',
+    summary: 'A starting configuration of the world.',
+    sections: [
+      {
+        kind: 'paragraph',
+        text:
+          'A scenario fixes the date, the chambers, the ruling parties, ' +
+          'baseline cohorts, and the events on the agenda. Different ' +
+          'scenarios make wildly different campaigns out of the same engine.',
+      },
+    ],
+    aliases: ['scenario'],
   },
 );

--- a/src/renderer/components/tooltip/index.ts
+++ b/src/renderer/components/tooltip/index.ts
@@ -12,3 +12,5 @@ export {
   type TooltipSection,
   type ModifierRow,
 } from './ExtendedTooltip';
+export { TermText } from './TermText';
+export { findTermMatches, type TermMatch } from './registry';

--- a/src/renderer/components/tooltip/matcher.test.ts
+++ b/src/renderer/components/tooltip/matcher.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tooltip auto-matcher tests — surface scanning, alias resolution,
+ * overlap rejection, longest-first preference.
+ *
+ * These tests exercise `findTermMatches` against a fresh registry per
+ * case so we never depend on the production glossary.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerTooltip,
+  clearTooltips,
+  findTermMatches,
+} from './registry';
+
+describe('findTermMatches', () => {
+  beforeEach(() => {
+    clearTooltips();
+  });
+
+  it('returns no matches for an empty registry', () => {
+    expect(findTermMatches('Spend PC to whip a vote.')).toEqual([]);
+  });
+
+  it('returns no matches for empty text', () => {
+    registerTooltip({ id: 'pc', title: 'Political Capital', sections: [], aliases: ['PC'] });
+    expect(findTermMatches('')).toEqual([]);
+  });
+
+  it('matches a registered title (case-insensitive)', () => {
+    registerTooltip({ id: 'pc', title: 'Political Capital', sections: [] });
+    const m = findTermMatches('Spend political capital wisely.');
+    expect(m).toHaveLength(1);
+    expect(m[0].id).toBe('pc');
+    expect(m[0].surface).toBe('political capital');
+  });
+
+  it('matches aliases as well as titles', () => {
+    registerTooltip({
+      id: 'pc',
+      title: 'Political Capital',
+      sections: [],
+      aliases: ['PC'],
+    });
+    const m = findTermMatches('Spend PC and political capital here.');
+    expect(m.map((x) => x.surface)).toEqual(['PC', 'political capital']);
+    expect(m.every((x) => x.id === 'pc')).toBe(true);
+  });
+
+  it('preserves original casing in the surface field', () => {
+    registerTooltip({ id: 'pc', title: 'Political Capital', sections: [] });
+    const m = findTermMatches('POLITICAL CAPITAL is shouted here.');
+    expect(m[0].surface).toBe('POLITICAL CAPITAL');
+  });
+
+  it('only matches whole words — "AP" does not match inside "trapping"', () => {
+    registerTooltip({
+      id: 'ap',
+      title: 'Action Points',
+      sections: [],
+      aliases: ['AP'],
+    });
+    expect(findTermMatches('A trapping for the unwary.')).toEqual([]);
+  });
+
+  it('returns matches in document order', () => {
+    registerTooltip({ id: 'pc', title: 'Political Capital', sections: [] });
+    registerTooltip({ id: 'ap', title: 'Action Points', sections: [] });
+    const m = findTermMatches('First Action Points then Political Capital.');
+    expect(m.map((x) => x.id)).toEqual(['ap', 'pc']);
+    expect(m[0].start).toBeLessThan(m[1].start);
+  });
+
+  it('prefers the longer surface when two terms overlap', () => {
+    // Registering a short alias and a longer title that contains it.
+    registerTooltip({
+      id: 'capital',
+      title: 'Capital',
+      sections: [],
+    });
+    registerTooltip({
+      id: 'pc',
+      title: 'Political Capital',
+      sections: [],
+    });
+    const m = findTermMatches('We need political capital now.');
+    expect(m).toHaveLength(1);
+    expect(m[0].id).toBe('pc');
+    expect(m[0].surface).toBe('political capital');
+  });
+
+  it('emits non-overlapping ranges for adjacent terms', () => {
+    registerTooltip({ id: 'pc', title: 'PC', sections: [] });
+    registerTooltip({ id: 'ap', title: 'AP', sections: [] });
+    const m = findTermMatches('Spend PC AP here.');
+    expect(m).toHaveLength(2);
+    expect(m[0].end).toBeLessThanOrEqual(m[1].start);
+  });
+
+  it('handles multiple occurrences of the same term', () => {
+    registerTooltip({ id: 'pc', title: 'PC', sections: [] });
+    const m = findTermMatches('PC then PC again then PC.');
+    expect(m).toHaveLength(3);
+    expect(m.every((x) => x.id === 'pc')).toBe(true);
+  });
+
+  it('escapes regex metacharacters in surfaces', () => {
+    registerTooltip({
+      id: 'cpp',
+      title: 'C++',
+      sections: [],
+      aliases: ['C++'],
+    });
+    const m = findTermMatches('We taught the AI C++ today.');
+    expect(m).toHaveLength(1);
+    expect(m[0].surface).toBe('C++');
+  });
+});

--- a/src/renderer/components/tooltip/registry.ts
+++ b/src/renderer/components/tooltip/registry.ts
@@ -93,6 +93,14 @@ export interface TooltipContent {
    * via a "See also" link row at the bottom.
    */
   seeAlso?: string[];
+  /**
+   * Surface forms that should auto-link to this tooltip when found in
+   * prose. The title is added implicitly. Aliases are case-insensitive
+   * and matched on whole-word boundaries only.
+   *
+   * @example aliases: ['PC', 'political capital'] for `political-capital`
+   */
+  aliases?: string[];
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -104,6 +112,7 @@ const REGISTRY = new Map<string, TooltipContent>();
 /** Register one or more tooltip definitions. Later writes override. */
 export function registerTooltip(...defs: TooltipContent[]): void {
   for (const d of defs) REGISTRY.set(d.id, d);
+  invalidateMatcher();
 }
 
 /** Look up a tooltip by id. Returns `undefined` if not registered. */
@@ -119,4 +128,129 @@ export function allTooltipIds(): string[] {
 /** Wipe the registry. Test-only convenience. */
 export function clearTooltips(): void {
   REGISTRY.clear();
+  invalidateMatcher();
+}
+
+// ────────────────────────────────────────────────────────────────
+// AUTO-MATCHER
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * One match emitted by {@link findTermMatches}.
+ *
+ * Indexes are character offsets into the *original* input string so
+ * the caller can splice the prose around them.
+ */
+export interface TermMatch {
+  /** Term id resolved from the registry. */
+  id: string;
+  /** Inclusive start offset in the source text. */
+  start: number;
+  /** Exclusive end offset in the source text. */
+  end: number;
+  /** The exact substring that matched (preserves original casing). */
+  surface: string;
+}
+
+/**
+ * The compiled matcher table. Built lazily from the registry the first
+ * time {@link findTermMatches} is called and invalidated whenever the
+ * registry changes.
+ *
+ * Each entry pairs a single regex (whole-word, case-insensitive) with
+ * the term id it resolves to. Surfaces are sorted longest-first so
+ * "political capital" wins over "capital" when both register.
+ */
+interface MatcherEntry {
+  id: string;
+  pattern: RegExp;
+}
+let MATCHER: MatcherEntry[] | null = null;
+
+function invalidateMatcher(): void {
+  MATCHER = null;
+}
+
+/** Escape a literal surface for use inside a RegExp. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Compile (or reuse) the surface → term-id matcher table. */
+function buildMatcher(): MatcherEntry[] {
+  if (MATCHER) return MATCHER;
+  // Collect (surface, id) pairs from titles + aliases. Surfaces are
+  // de-duplicated case-insensitively; later writes override earlier ones.
+  const surfaces = new Map<string, string>();
+  for (const def of REGISTRY.values()) {
+    const all = [def.title, ...(def.aliases ?? [])];
+    for (const surface of all) {
+      const key = surface.toLowerCase();
+      if (!surfaces.has(key)) surfaces.set(key, def.id);
+    }
+  }
+  // Longest-first so multi-word surfaces win over their suffixes.
+  const sorted = Array.from(surfaces.entries()).sort(
+    (a, b) => b[0].length - a[0].length,
+  );
+  // "Word boundary" here is a unicode-friendly assertion: the surface
+  // must not be touching letters/digits on either side. Plain `\b`
+  // does not work for multi-word surfaces because the inner spaces
+  // count as boundaries themselves.
+  MATCHER = sorted.map(([surface, id]) => ({
+    id,
+    pattern: new RegExp(`(^|[^\\p{L}\\p{N}])(${escapeRegex(surface)})(?=$|[^\\p{L}\\p{N}])`, 'iu'),
+  }));
+  return MATCHER;
+}
+
+/**
+ * Scan `text` for any registered term surface and return the matches
+ * in document order, with no overlaps.
+ *
+ * Algorithm: for each registered surface (longest-first), find every
+ * occurrence; reject matches that overlap an already-accepted match.
+ * Cost: O(terms × text) — fine for tooltip prose (rarely >1 KB).
+ *
+ * @example
+ *   findTermMatches('Spend PC to whip a vote.')
+ *   // → [{ id: 'political-capital', start: 6, end: 8, surface: 'PC' }]
+ */
+export function findTermMatches(text: string): TermMatch[] {
+  if (!text) return [];
+  const matcher = buildMatcher();
+  const accepted: TermMatch[] = [];
+
+  // Walk every term and collect candidate hits.
+  for (const { id, pattern } of matcher) {
+    // Build a global flavour of the per-term pattern for iteration.
+    const global = new RegExp(pattern.source, pattern.flags + 'g');
+    let m: RegExpExecArray | null;
+    while ((m = global.exec(text)) !== null) {
+      // The leading non-letter char is captured in group 1 and is *not*
+      // part of the term surface; strip it from the offset.
+      const lead = m[1] ?? '';
+      const surfaceStart = m.index + lead.length;
+      const surface = m[2];
+      const surfaceEnd = surfaceStart + surface.length;
+
+      // Reject if it overlaps any already-accepted match.
+      const overlaps = accepted.some(
+        (a) => surfaceStart < a.end && surfaceEnd > a.start,
+      );
+      if (overlaps) continue;
+      accepted.push({ id, start: surfaceStart, end: surfaceEnd, surface });
+      // Advance past the match to avoid zero-width loops on edge cases.
+      if (global.lastIndex === m.index) global.lastIndex++;
+    }
+  }
+
+  // Sort the accepted matches by document order for the consumer.
+  accepted.sort((a, b) => a.start - b.start);
+  return accepted;
+}
+
+/** Force the matcher to recompile. Test-only. */
+export function _resetMatcherForTest(): void {
+  invalidateMatcher();
 }

--- a/src/renderer/panels/DashboardPanel.tsx
+++ b/src/renderer/panels/DashboardPanel.tsx
@@ -8,6 +8,7 @@ import { Bar } from '../components/Bar';
 import { Button } from '../components/Button';
 import { Icon, type IconName } from '../components/Icon';
 import { IdeologyCompass } from '../components/IdeologyCompass';
+import { TermText } from '../components/tooltip';
 import { formatBillionsUSD, describeIdeology } from '@/utils/format';
 import type { Bill, BillStage } from '@/types';
 
@@ -415,7 +416,7 @@ function NewsColumn({
               </div>
               {n.body && (
                 <p className="text-[0.8125rem] text-text-secondary mt-0.5 leading-snug">
-                  {n.body}
+                  <TermText text={n.body} />
                 </p>
               )}
             </li>

--- a/src/renderer/panels/LegislationPanel.tsx
+++ b/src/renderer/panels/LegislationPanel.tsx
@@ -12,6 +12,7 @@ import { toEpochDays } from '@/utils/date';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { Bar } from '../components/Bar';
+import { TermText } from '../components/tooltip';
 import type { Bill, BillId, BillStage, BillTemplate } from '@/types';
 
 /**
@@ -103,7 +104,7 @@ export function LegislationPanel(): JSX.Element {
               (t.stageDurations?.vote ?? STAGE_DURATION_DAYS.vote);
             return (
               <Card key={t.id} title={t.title} accent="gold">
-                <p className="text-sm text-text-secondary mb-2">{t.description}</p>
+                <p className="text-sm text-text-secondary mb-2"><TermText text={t.description} /></p>
                 <div className="text-xs text-text-muted flex flex-wrap gap-2 mb-3">
                   {t.tags.map((tag) => (
                     <span key={tag} className="bg-bg-tertiary rounded px-2 py-0.5">
@@ -215,7 +216,7 @@ function PendingBillCard({
 
   return (
     <Card title={bill.title} subtitle={stageLabel(bill.stage)} accent="gold">
-      <p className="text-sm text-text-secondary mb-3">{bill.description}</p>
+      <p className="text-sm text-text-secondary mb-3"><TermText text={bill.description} /></p>
 
       {clocked && totalDays > 0 && (
         <div className="mb-3">

--- a/src/renderer/panels/QuestsPanel.tsx
+++ b/src/renderer/panels/QuestsPanel.tsx
@@ -5,6 +5,7 @@ import { useWorldStore } from '@/store/worldStore';
 import { useUIStore } from '@/store/uiStore';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
+import { TermText } from '../components/tooltip';
 import type { QuestDefinition, QuestId } from '@/types';
 
 export function QuestsPanel(): JSX.Element {
@@ -50,7 +51,7 @@ export function QuestsPanel(): JSX.Element {
             const doneCount = def.objectives.filter((o) => inst.progress[o.id]).length;
             return (
               <Card key={inst.instanceId} title={def.title} subtitle={`Status: ${inst.status}`} accent="gold">
-                <p className="text-sm text-text-secondary mb-3">{def.description}</p>
+                <p className="text-sm text-text-secondary mb-3"><TermText text={def.description} /></p>
                 <ul className="space-y-1 text-sm">
                   {def.objectives.map((o) => (
                     <li key={o.id} className="flex items-start gap-2">

--- a/tests/e2e/auto-tooltip.spec.ts
+++ b/tests/e2e/auto-tooltip.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Auto-Tooltip suite — verifies that:
+ *   (1) Glossary terms in prose auto-link via <TermText>.
+ *   (2) Hovering a term shows the radial hold ring, then auto-pins
+ *       the tooltip after the configured hold window.
+ *   (3) An outside click closes a pinned tooltip.
+ *   (4) Pressing Escape closes a pinned tooltip.
+ *
+ * The character-creation flow is reused (matches the Cards & Tooltip
+ * suite) so these tests run from a known dashboard state.
+ */
+
+interface GameStoreBridge {
+  getState: () => { setPaused: (paused: boolean) => void };
+}
+
+async function goToGame(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  await page.getByRole('button', { name: /new game/i }).click();
+  await page.waitForSelector('text=Build Your Candidate', { timeout: 8_000 });
+
+  await page.fill('input[placeholder*="Jordan"]', 'Alex Rivera');
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(200);
+
+  await page.waitForSelector('text=Core Stats', { timeout: 4_000 });
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(200);
+
+  await page.getByText(/Pick 1.{1,3}3/).waitFor({ timeout: 4_000 });
+  await page.getByRole('button', { name: /grassroots organizer/i }).click();
+  await page.waitForTimeout(150);
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(200);
+
+  await page.waitForSelector('text=Where do you stand?', { timeout: 4_000 });
+  await page.getByRole('button', { name: /choose scenario/i }).click();
+  await page.waitForTimeout(300);
+
+  await page.waitForSelector('text=Choose Your Arena', { timeout: 6_000 });
+  await page.getByRole('button', { name: /^begin$/i }).first().click();
+  await page.waitForTimeout(400);
+
+  await page.waitForSelector('text=Dashboard', { timeout: 8_000 });
+
+  // Pause the sim so weekly ticks don't reshuffle the dashboard during
+  // hover timing measurements.
+  await page.evaluate(() => {
+    const gs = (window as unknown as { __gameStore?: GameStoreBridge }).__gameStore;
+    gs?.getState().setPaused(true);
+  });
+  await page.waitForTimeout(150);
+}
+
+test.describe('auto-tooltip + hold-to-lock', () => {
+  // The radial hold defaults to 1200ms in ExtendedTooltip; leave headroom.
+  const HOLD_MS = 1200;
+  const HOLD_BUFFER_MS = 600;
+
+  test('hovering Political Capital shows radial then locks', async ({ page }) => {
+    await goToGame(page);
+
+    const pcPill = page.locator('text=PC').first();
+    await pcPill.hover();
+    // Wait for tooltip to appear (openDelay = 350ms).
+    const tip = page.getByRole('tooltip');
+    await expect(tip).toBeVisible({ timeout: 2000 });
+
+    // Radial appears mid-hold. We allow either visible-but-still-filling
+    // or already-locked; the key invariant is that pinned-mode UI
+    // ("Click outside or press Esc") shows up after the full hold.
+    await page.waitForTimeout(HOLD_MS + HOLD_BUFFER_MS);
+    await expect(tip).toContainText(/click outside or press/i);
+  });
+
+  test('outside click closes a locked tooltip', async ({ page }) => {
+    await goToGame(page);
+
+    const pcPill = page.locator('text=PC').first();
+    await pcPill.hover();
+    const tip = page.getByRole('tooltip');
+    await expect(tip).toBeVisible({ timeout: 2000 });
+    await page.waitForTimeout(HOLD_MS + HOLD_BUFFER_MS);
+    await expect(tip).toContainText(/click outside or press/i);
+
+    // Click a neutral region of the page background. Use the body's
+    // bottom-left corner to be sure we're nowhere near the trigger or
+    // the tooltip card itself.
+    await page.mouse.move(20, 20);
+    await page.mouse.click(20, 20);
+    await expect(tip).toBeHidden({ timeout: 1500 });
+  });
+
+  test('Escape closes a locked tooltip', async ({ page }) => {
+    await goToGame(page);
+
+    const pcPill = page.locator('text=PC').first();
+    await pcPill.hover();
+    const tip = page.getByRole('tooltip');
+    await expect(tip).toBeVisible({ timeout: 2000 });
+    await page.waitForTimeout(HOLD_MS + HOLD_BUFFER_MS);
+
+    await page.keyboard.press('Escape');
+    await expect(tip).toBeHidden({ timeout: 1500 });
+  });
+});


### PR DESCRIPTION
Stacks on #49 (xp--cards-and-tooltips). Once that lands in xperimental, this PR's base can be retargeted.

## Summary

Two things, both extending the Paradox-style ExtendedTooltip system:

1. **<TermText> auto-links glossary terms in plain prose.** Previously, every term needed a manual <Term term=... > wrapper or a [term:...] inline marker. Now any registered surface (title or alias) gets matched and wrapped automatically. Aliases mean `PC` -> Political Capital, `AP` -> Action Points, etc.
2. **Hold-to-lock tooltips.** Hovering a term shows a gold radial progress arc in the tooltip's top-right corner. After 1.2s the tooltip auto-pins. Outside-click (capture-phase) or Esc closes it. Footer text changes to reflect mode.

## Files

- `registry.ts` - new `findTermMatches()` matcher: longest-first, non-overlapping, unicode word boundaries, lazy compiled-pattern cache.
- `glossary.ts` - +16 terms (bill, committee, floor-vote, whip, veto, cohort, radicalism, approval, turnout, gdp, unemployment, deficit, scandal, quest, event, scenario); aliases on every existing entry.
- `ExtendedTooltip.tsx` - `lockHoldMs` prop (default 1200ms), rAF hold loop, `HoldRing` SVG component, outside-click effect, mode-aware footer hints.
- `TermText.tsx` (new) - splices matches into a node array; supports `exclude` and `limit` props.
- Wired into `CardFace` (description + flavour), `DashboardPanel` news, `LegislationPanel`, `QuestsPanel`.

## Tests

- 11 new Vitest cases for the matcher (`matcher.test.ts`).
- 3 new Playwright e2e tests (`auto-tooltip.spec.ts`) verifying radial-then-lock, outside-click-close, Escape-close.
- Run across `1280x720`, `1440x900`, `1920x1080`: 9/9 green.
- `npm run typecheck`, `npm run lint`, `npm test` (123 tests) all green.

## Docs

- `docs/about/CHANGELOG.md` updated under [Unreleased].

Refs the user's PR1 batch (auto-link tooltips + hold-to-lock).