### PR TITLE
feat(ui,character): bigger ideology compass + reference figures + live orientation

### DIFF
--- a/docs/about/CHANGELOG.md
+++ b/docs/about/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Political Ascent are recorded here.
 ## [Unreleased]
 
 ### Added
+- **Ideology compass redesign** (`exp--ideology-compass`).
+  - `IdeologyCompass` rebuilt as a larger (default `size=320`, `360` in character creation) interactive picker. Click anywhere, drag the marker (Pointer Events with `setPointerCapture`), or use arrow keys (Shift = larger step) to set position. `role="slider"` + `aria-valuetext` for screen readers.
+  - **Raw numeric coordinates are no longer shown.** The `x = … · y = …` font-mono readout in character-creation step 3 is gone. In its place a live orientation label (`data-testid="ideology-orientation"`, `aria-live="polite"`) reads e.g. "Centrist", "Moderate Right", "Strong Left-Libertarian".
+  - New `ideologyLabel(point)` utility (`src/renderer/components/ideologyLabel.ts`) maps a 2-axis point to a human label using a 0.15 axis dead-zone, "Moderate" prefix below 0.4 magnitude, and "Strong" prefix at/above 0.75. 7 Vitest cases.
+  - **Historical reference figures**: 20 ghost markers (FDR, JFK, Lincoln, Reagan, Sanders, AOC, Thatcher, Goldwater, Friedman, Chomsky, Mill, Rand, MLK, …) loaded from `src/data/ideology/reference-figures.json`. Hover (or focus) shows a tooltip with name and era. Quadrant labels (Lib-Left / Lib-Right / Auth-Left / Auth-Right) inset into the field.
+  - 4 new Playwright tests (`tests/e2e/ideology-compass.spec.ts`) verifying live orientation, no raw-coord exposure, ghost-figure plotting, hover tooltip, and real-time label updates across `1280×720`, `1440×900`, `1920×1080`.
+
 - **Auto-tooltip terms + hold-to-lock** (`exp--auto-tooltip-terms`).
   - `<TermText text="..." />` (`src/renderer/components/tooltip/TermText.tsx`) auto-links any registered glossary surface (title or alias) found in plain prose, eliminating the need to wrap each term manually.
   - Glossary matcher (`registry.ts → findTermMatches`): longest-first preference, non-overlapping ranges, unicode word-boundary regex, lazy compiled-pattern cache invalidated on `registerTooltip` / `clearTooltips`. 11 new Vitest cases.

--- a/src/data/ideology/reference-figures.json
+++ b/src/data/ideology/reference-figures.json
@@ -1,0 +1,25 @@
+{
+  "$schemaVersion": 1,
+  "figures": [
+    { "id": "fdr",        "name": "Franklin D. Roosevelt", "era": "1933–1945 · Democrat",   "x": -0.55, "y":  0.25 },
+    { "id": "lbj",        "name": "Lyndon B. Johnson",     "era": "1963–1969 · Democrat",   "x": -0.40, "y":  0.40 },
+    { "id": "jfk",        "name": "John F. Kennedy",       "era": "1961–1963 · Democrat",   "x": -0.20, "y":  0.10 },
+    { "id": "lincoln",    "name": "Abraham Lincoln",       "era": "1861–1865 · Republican", "x":  0.05, "y":  0.40 },
+    { "id": "eisenhower", "name": "Dwight D. Eisenhower",  "era": "1953–1961 · Republican", "x":  0.30, "y":  0.30 },
+    { "id": "nixon",      "name": "Richard Nixon",         "era": "1969–1974 · Republican", "x":  0.50, "y":  0.60 },
+    { "id": "reagan",     "name": "Ronald Reagan",         "era": "1981–1989 · Republican", "x":  0.70, "y":  0.30 },
+    { "id": "carter",     "name": "Jimmy Carter",          "era": "1977–1981 · Democrat",   "x": -0.30, "y": -0.10 },
+    { "id": "obama",      "name": "Barack Obama",          "era": "2009–2017 · Democrat",   "x": -0.30, "y":  0.10 },
+    { "id": "clinton",    "name": "Bill Clinton",          "era": "1993–2001 · Democrat",   "x":  0.10, "y":  0.20 },
+    { "id": "sanders",    "name": "Bernie Sanders",        "era": "Senator · Independent",  "x": -0.80, "y": -0.25 },
+    { "id": "aoc",        "name": "Alexandria Ocasio-Cortez","era": "Rep. · Democrat",       "x": -0.70, "y": -0.35 },
+    { "id": "thatcher",   "name": "Margaret Thatcher",     "era": "UK PM 1979–1990",        "x":  0.80, "y":  0.50 },
+    { "id": "goldwater",  "name": "Barry Goldwater",       "era": "Senator · Republican",   "x":  0.60, "y": -0.35 },
+    { "id": "wallace",    "name": "George Wallace",        "era": "Governor · Democrat",    "x":  0.25, "y":  0.75 },
+    { "id": "friedman",   "name": "Milton Friedman",       "era": "Economist · Theorist",   "x":  0.75, "y": -0.60 },
+    { "id": "chomsky",    "name": "Noam Chomsky",          "era": "Theorist · Anarchist",   "x": -0.85, "y": -0.70 },
+    { "id": "mill",       "name": "John Stuart Mill",      "era": "Philosopher · 1806–73",  "x": -0.15, "y": -0.70 },
+    { "id": "rand",       "name": "Ayn Rand",              "era": "Philosopher · 1905–82",  "x":  0.80, "y": -0.75 },
+    { "id": "mlk",        "name": "Martin Luther King Jr.","era": "Civil Rights · 1929–68", "x": -0.50, "y": -0.50 }
+  ]
+}

--- a/src/renderer/components/IdeologyCompass.tsx
+++ b/src/renderer/components/IdeologyCompass.tsx
@@ -1,70 +1,253 @@
 /**
- * IdeologyCompass — interactive or read-only 2-axis political compass.
+ * IdeologyCompass — interactive 2-axis political compass.
  *
- * Coordinates are normalized to [-1, +1] on both axes.
+ * Displays the player's ideology on the same coordinate system used by
+ * legislators and the seating chart (x = economic axis, y = freedom axis,
+ * each in [-1, +1]). The component is two things at once:
+ *
+ *   1. A *picker* — when `onChange` is supplied, the user can click or drag
+ *      anywhere inside the field to set the point. Keyboard arrows nudge it.
+ *   2. A *display* — when `onChange` is omitted, it's a static plot of the
+ *      player's stance.
+ *
+ * Visual goals (from the GDD redesign):
+ *   - Bigger by default; legibility is the top priority.
+ *   - The raw numeric coordinates are NEVER shown — players think in
+ *     orientations ("Left-Libertarian"), not in floats.
+ *   - A real-time orientation label updates as the marker moves.
+ *   - Optional reference-figure ghost markers (FDR, Reagan, Sanders, etc.)
+ *     load from `src/data/ideology/reference-figures.json` and tooltip on
+ *     hover. They give the player a sense of where their stance sits in
+ *     historical context.
+ *
+ * @module renderer/components/IdeologyCompass
+ * @see ideologyLabel
+ * @see ../components/Hemicycle (consumes the same axes for seating)
  */
-import { useCallback, useRef, type MouseEvent } from 'react';
+import { useCallback, useRef, useState, type KeyboardEvent, type PointerEvent } from 'react';
 import type { IdeologyPoint } from '@/types';
+import { ideologyLabel } from './ideologyLabel';
+import figuresData from '@/data/ideology/reference-figures.json';
 
-export interface IdeologyCompassProps {
-  value: IdeologyPoint;
-  onChange?: (next: IdeologyPoint) => void;
-  size?: number;
-  label?: boolean;
+// ─────────────────────────────────────────────────────────────
+// Reference figures
+// Loaded once at module evaluation. The JSON file is the single
+// source of truth — adding a figure there is enough to plot it.
+// ─────────────────────────────────────────────────────────────
+interface ReferenceFigure {
+  id: string;
+  name: string;
+  era: string;
+  x: number;
+  y: number;
 }
 
-export function IdeologyCompass(props: IdeologyCompassProps): JSX.Element {
-  const { value, onChange, size = 240, label = true } = props;
-  const ref = useRef<HTMLDivElement>(null);
+const REFERENCE_FIGURES: readonly ReferenceFigure[] = (
+  figuresData as { figures: ReferenceFigure[] }
+).figures;
 
-  const handleClick = useCallback(
-    (e: MouseEvent<HTMLDivElement>) => {
-      if (!onChange || !ref.current) return;
-      const rect = ref.current.getBoundingClientRect();
-      const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-      const y = ((e.clientY - rect.top) / rect.height) * 2 - 1;
-      onChange({
-        x: Math.max(-1, Math.min(1, x)),
-        y: Math.max(-1, Math.min(1, y)),
-      });
+export interface IdeologyCompassProps {
+  /** Current ideology point in normalised [-1, +1] coordinates. */
+  value: IdeologyPoint;
+  /** When provided, the compass becomes interactive (click + drag + keys). */
+  onChange?: (next: IdeologyPoint) => void;
+  /** Pixel size of the square plot area. Default 320. */
+  size?: number;
+  /** Render the axis labels under the compass. Default true. */
+  label?: boolean;
+  /** Render historical ghost markers. Default true. */
+  showReferenceFigures?: boolean;
+}
+
+/**
+ * IdeologyCompass — see file header for details.
+ */
+export function IdeologyCompass(props: IdeologyCompassProps): JSX.Element {
+  const {
+    value,
+    onChange,
+    size = 320,
+    label = true,
+    showReferenceFigures = true,
+  } = props;
+
+  const ref = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [hoverFigureId, setHoverFigureId] = useState<string | null>(null);
+
+  const interactive = !!onChange;
+
+  // Derive coordinates from a pointer position relative to the plot box.
+  const pointToValue = useCallback((clientX: number, clientY: number): IdeologyPoint | null => {
+    if (!ref.current) return null;
+    const rect = ref.current.getBoundingClientRect();
+    const x = ((clientX - rect.left) / rect.width) * 2 - 1;
+    const y = ((clientY - rect.top) / rect.height) * 2 - 1;
+    return {
+      x: Math.max(-1, Math.min(1, x)),
+      y: Math.max(-1, Math.min(1, y)),
+    };
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (!onChange) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      setDragging(true);
+      const next = pointToValue(e.clientX, e.clientY);
+      if (next) onChange(next);
+    },
+    [onChange, pointToValue],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (!onChange || !dragging) return;
+      const next = pointToValue(e.clientX, e.clientY);
+      if (next) onChange(next);
+    },
+    [onChange, dragging, pointToValue],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (!onChange) return;
+      e.currentTarget.releasePointerCapture(e.pointerId);
+      setDragging(false);
     },
     [onChange],
   );
 
-  // Map [-1,+1] to [0%,100%] for CSS placement.
-  const leftPct = ((value.x + 1) / 2) * 100;
-  const topPct = ((value.y + 1) / 2) * 100;
+  // Keyboard accessibility: arrow keys nudge by 5% per press, shift = 15%.
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (!onChange) return;
+      const step = e.shiftKey ? 0.15 : 0.05;
+      let dx = 0;
+      let dy = 0;
+      switch (e.key) {
+        case 'ArrowLeft':  dx = -step; break;
+        case 'ArrowRight': dx =  step; break;
+        case 'ArrowUp':    dy = -step; break;
+        case 'ArrowDown':  dy =  step; break;
+        default: return;
+      }
+      e.preventDefault();
+      onChange({
+        x: Math.max(-1, Math.min(1, value.x + dx)),
+        y: Math.max(-1, Math.min(1, value.y + dy)),
+      });
+    },
+    [onChange, value],
+  );
+
+  // Map [-1, +1] → [0, 100] for CSS percentage placement.
+  const toPct = (n: number): number => ((n + 1) / 2) * 100;
+  const leftPct = toPct(value.x);
+  const topPct = toPct(value.y);
+
+  const orientation = ideologyLabel(value);
+  const hoveredFigure = hoverFigureId
+    ? REFERENCE_FIGURES.find((f) => f.id === hoverFigureId) ?? null
+    : null;
 
   return (
     <div className="inline-block">
       <div
         ref={ref}
-        role={onChange ? 'button' : 'img'}
-        aria-label="Ideology compass"
-        onClick={handleClick}
+        role={interactive ? 'slider' : 'img'}
+        tabIndex={interactive ? 0 : -1}
+        aria-label={
+          interactive
+            ? `Ideology compass — ${orientation}. Use arrow keys to adjust.`
+            : `Ideology compass — ${orientation}`
+        }
+        aria-valuetext={orientation}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onKeyDown={handleKeyDown}
         style={{ width: size, height: size }}
-        className={`relative bg-bg-tertiary rounded border border-bg-tertiary select-none ${
-          onChange ? 'cursor-crosshair' : ''
+        className={`relative bg-bg-tertiary rounded border border-bg-tertiary select-none touch-none ${
+          interactive ? 'cursor-crosshair focus:outline focus:outline-2 focus:outline-accent-gold' : ''
         }`}
+        data-testid="ideology-compass"
       >
-        {/* Quadrant backgrounds */}
-        <div className="absolute inset-0 grid grid-cols-2 grid-rows-2">
+        {/* Quadrant tints — economic-left in cool blue, economic-right in warm red. */}
+        <div className="absolute inset-0 grid grid-cols-2 grid-rows-2 pointer-events-none">
           <div className="bg-accent-blue/10" />
           <div className="bg-accent-red/10" />
           <div className="bg-accent-blue/20" />
           <div className="bg-accent-red/20" />
         </div>
-        {/* Axes */}
-        <div className="absolute inset-x-0 top-1/2 h-px bg-text-muted/40" />
-        <div className="absolute inset-y-0 left-1/2 w-px bg-text-muted/40" />
-        {/* Marker */}
+
+        {/* Quadrant labels — small, inset, low contrast so they don't fight the marker. */}
+        <div className="absolute inset-0 pointer-events-none text-[10px] uppercase tracking-wider text-text-muted/70 font-headline">
+          <span className="absolute top-1.5 left-1.5">Lib-Left</span>
+          <span className="absolute top-1.5 right-1.5">Lib-Right</span>
+          <span className="absolute bottom-1.5 left-1.5">Auth-Left</span>
+          <span className="absolute bottom-1.5 right-1.5">Auth-Right</span>
+        </div>
+
+        {/* Centre cross-hairs */}
+        <div className="absolute inset-x-0 top-1/2 h-px bg-text-muted/40 pointer-events-none" />
+        <div className="absolute inset-y-0 left-1/2 w-px bg-text-muted/40 pointer-events-none" />
+
+        {/* Reference-figure ghost markers */}
+        {showReferenceFigures &&
+          REFERENCE_FIGURES.map((fig) => (
+            <button
+              key={fig.id}
+              type="button"
+              tabIndex={-1}
+              onMouseEnter={() => setHoverFigureId(fig.id)}
+              onMouseLeave={() => setHoverFigureId((cur) => (cur === fig.id ? null : cur))}
+              onFocus={() => setHoverFigureId(fig.id)}
+              onBlur={() => setHoverFigureId((cur) => (cur === fig.id ? null : cur))}
+              className="absolute w-2 h-2 rounded-full bg-text-muted/70 ring-1 ring-bg-primary -translate-x-1/2 -translate-y-1/2 hover:bg-accent-gold hover:scale-150 transition-transform"
+              style={{ left: `${toPct(fig.x)}%`, top: `${toPct(fig.y)}%` }}
+              aria-label={`${fig.name} — ${fig.era}`}
+              data-testid={`ref-figure-${fig.id}`}
+            />
+          ))}
+
+        {/* Player marker — drawn last so it's always on top. */}
         <div
-          className="absolute w-3 h-3 rounded-full bg-accent-gold ring-2 ring-accent-gold/40 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
+          className="absolute w-4 h-4 rounded-full bg-accent-gold ring-2 ring-accent-gold/50 -translate-x-1/2 -translate-y-1/2 pointer-events-none shadow-lg"
           style={{ left: `${leftPct}%`, top: `${topPct}%` }}
+          data-testid="ideology-marker"
         />
+
+        {/* Hover tooltip for a reference figure */}
+        {hoveredFigure && (
+          <div
+            className="absolute z-10 px-2 py-1 rounded bg-bg-primary border border-accent-gold/40 text-xs whitespace-nowrap pointer-events-none -translate-x-1/2 -translate-y-full"
+            style={{
+              left: `${toPct(hoveredFigure.x)}%`,
+              top: `calc(${toPct(hoveredFigure.y)}% - 10px)`,
+            }}
+            role="tooltip"
+          >
+            <div className="font-headline text-accent-gold">{hoveredFigure.name}</div>
+            <div className="text-text-muted">{hoveredFigure.era}</div>
+          </div>
+        )}
       </div>
+
+      {/* Live orientation readout — replaces the raw numeric coordinates. */}
+      <div
+        className="mt-2 text-sm font-headline text-accent-gold text-center"
+        data-testid="ideology-orientation"
+        aria-live="polite"
+      >
+        {orientation}
+      </div>
+
       {label && (
-        <div className="mt-2 text-xs text-text-secondary grid grid-cols-2 gap-x-4 max-w-[240px]">
+        <div
+          className="mt-1 text-xs text-text-secondary grid grid-cols-2 gap-x-4"
+          style={{ width: size }}
+        >
           <span>← Economic Left</span>
           <span className="text-right">Economic Right →</span>
           <span>↑ Libertarian</span>

--- a/src/renderer/components/ideologyLabel.test.ts
+++ b/src/renderer/components/ideologyLabel.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { ideologyLabel } from './ideologyLabel';
+
+describe('ideologyLabel', () => {
+  it('returns Centrist at the origin', () => {
+    expect(ideologyLabel({ x: 0, y: 0 })).toBe('Centrist');
+  });
+
+  it('returns Centrist anywhere inside the deadzone', () => {
+    expect(ideologyLabel({ x: 0.1, y: -0.1 })).toBe('Centrist');
+  });
+
+  it('uses single-axis label when perpendicular axis is in the deadzone', () => {
+    expect(ideologyLabel({ x: -0.5, y: 0.05 })).toBe('Left');
+    expect(ideologyLabel({ x: 0.05, y: 0.5 })).toBe('Authoritarian');
+  });
+
+  it('compounds quadrant when both axes are out of the deadzone', () => {
+    expect(ideologyLabel({ x: -0.5, y: -0.5 })).toBe('Left-Libertarian');
+    expect(ideologyLabel({ x: 0.5, y: 0.5 })).toBe('Right-Authoritarian');
+  });
+
+  it('prefixes "Moderate" for low-intensity points', () => {
+    expect(ideologyLabel({ x: -0.3, y: -0.3 })).toBe('Moderate Left-Libertarian');
+  });
+
+  it('prefixes "Strong" for high-intensity points', () => {
+    expect(ideologyLabel({ x: 0.85, y: -0.6 })).toBe('Strong Right-Libertarian');
+  });
+
+  it('uses the max axis magnitude for intensity, not the norm', () => {
+    // x is strong, y is moderate — should still read as "Strong".
+    expect(ideologyLabel({ x: -0.8, y: 0.3 })).toBe('Strong Left-Authoritarian');
+  });
+});

--- a/src/renderer/components/ideologyLabel.ts
+++ b/src/renderer/components/ideologyLabel.ts
@@ -1,0 +1,73 @@
+/**
+ * ideologyLabel — derive a human-readable orientation phrase from an
+ * IdeologyPoint on the 2-axis political compass.
+ *
+ * The compass axes follow the in-game convention:
+ *   x ∈ [-1, +1]  (-1 = economic left, +1 = economic right)
+ *   y ∈ [-1, +1]  (-1 = libertarian / personal-freedom, +1 = authoritarian)
+ *
+ * The output is intentionally short and shippable in UI strings — it
+ * gates on (a) which quadrant the point sits in and (b) the magnitude
+ * along each axis. A "Centrist" pole exists so a player parked at the
+ * origin doesn't get a noisy compound label.
+ *
+ * @module renderer/components/ideologyLabel
+ */
+
+import type { IdeologyPoint } from '@/types';
+
+// ─────────────────────────────────────────────────────────────
+// Thresholds
+// Tuned so the central deadzone is small enough that even modest
+// movement produces a label change (good for real-time feedback)
+// while preventing flicker between "Centrist" and a quadrant name
+// when the user is just resting at the origin.
+// ─────────────────────────────────────────────────────────────
+const AXIS_DEADZONE = 0.15;
+const MODERATE_MAX = 0.4;
+const STRONG_MIN = 0.75;
+
+/**
+ * Map an IdeologyPoint to a short orientation label.
+ *
+ * @param p - point on the political compass
+ * @returns label such as "Centrist", "Moderate Left-Libertarian",
+ *          "Strong Right-Authoritarian", "Authoritarian", etc.
+ *
+ * @example
+ * ideologyLabel({ x: 0, y: 0 });           // "Centrist"
+ * ideologyLabel({ x: -0.8, y: -0.6 });     // "Strong Left-Libertarian"
+ * ideologyLabel({ x: 0.05, y: 0.5 });      // "Authoritarian"
+ */
+export function ideologyLabel(p: IdeologyPoint): string {
+  const ax = Math.abs(p.x);
+  const ay = Math.abs(p.y);
+
+  // Pure centre — both axes inside the deadzone.
+  if (ax < AXIS_DEADZONE && ay < AXIS_DEADZONE) {
+    return 'Centrist';
+  }
+
+  // Single-axis labels when the other axis is in the deadzone — avoids
+  // saying "Left-Authoritarian" when the auth/lib reading is basically
+  // zero. Reads more naturally in UI.
+  const xName = p.x < 0 ? 'Left' : 'Right';
+  const yName = p.y < 0 ? 'Libertarian' : 'Authoritarian';
+
+  let core: string;
+  if (ay < AXIS_DEADZONE) {
+    core = xName;
+  } else if (ax < AXIS_DEADZONE) {
+    core = yName;
+  } else {
+    core = `${xName}-${yName}`;
+  }
+
+  // Intensity is the larger of the two axis magnitudes — using the max
+  // (not the L2 norm) means a single-axis extremist still reads as
+  // "Strong …" even if the perpendicular axis is moderate.
+  const intensity = Math.max(ax, ay);
+  if (intensity >= STRONG_MIN) return `Strong ${core}`;
+  if (intensity <= MODERATE_MAX) return `Moderate ${core}`;
+  return core;
+}

--- a/src/renderer/panels/CharacterPanel.tsx
+++ b/src/renderer/panels/CharacterPanel.tsx
@@ -41,7 +41,12 @@ export function CharacterPanel(): JSX.Element {
       </Card>
 
       <Card title="Ideology">
-        <IdeologyCompass value={char.ideology} size={220} label />
+        <IdeologyCompass
+          value={char.ideology}
+          size={240}
+          label
+          showReferenceFigures={false}
+        />
       </Card>
 
       <Card title="Progression" accent="gold">

--- a/src/renderer/screens/CharacterCreation.tsx
+++ b/src/renderer/screens/CharacterCreation.tsx
@@ -195,13 +195,17 @@ export function CharacterCreation(): JSX.Element {
         {step === 3 && (
           <Card title="Ideology" subtitle="Where do you stand?">
             <div className="flex flex-col md:flex-row gap-6 items-start">
-              <IdeologyCompass value={ideology} onChange={setIdeology} />
-              <div className="text-sm text-text-secondary max-w-sm">
-                <p>Your ideology influences how legislators in each party react to you and which
-                  events/cards you&rsquo;ll naturally lean into. You can drift later, but this is your
-                  starting posture.</p>
-                <p className="mt-3 font-mono text-xs">
-                  x = {ideology.x.toFixed(2)} &middot; y = {ideology.y.toFixed(2)}
+              <IdeologyCompass value={ideology} onChange={setIdeology} size={360} />
+              <div className="text-sm text-text-secondary max-w-sm space-y-3">
+                <p>
+                  Your ideology influences how legislators in each party react to you and
+                  which events/cards you&rsquo;ll naturally lean into. You can drift later,
+                  but this is your starting posture.
+                </p>
+                <p>
+                  Drag the marker, click anywhere on the grid, or use the arrow keys
+                  (Shift for larger steps). Hover the small grey dots to compare your
+                  position to historical and contemporary figures.
                 </p>
               </div>
             </div>

--- a/tests/e2e/ideology-compass.spec.ts
+++ b/tests/e2e/ideology-compass.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Ideology compass redesign — verifies that the rebuilt compass:
+ *   (1) Renders large, with quadrant labels and a live orientation readout.
+ *   (2) Hides the raw numeric coordinates entirely (no `x = …` text).
+ *   (3) Plots the historical reference figures as ghost markers and
+ *       shows a tooltip on hover.
+ *   (4) Updates the orientation label in real time when the marker moves
+ *       via keyboard arrows.
+ *
+ * Stops at the Ideology step of character creation — we don't need to
+ * complete the flow.
+ */
+
+async function goToIdeologyStep(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  await page.getByRole('button', { name: /new game/i }).click();
+  await page.waitForSelector('text=Build Your Candidate', { timeout: 8_000 });
+
+  await page.fill('input[placeholder*="Jordan"]', 'Alex Rivera');
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(150);
+
+  await page.waitForSelector('text=Core Stats', { timeout: 4_000 });
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(150);
+
+  await page.getByText(/Pick 1.{1,3}3/).waitFor({ timeout: 4_000 });
+  await page.getByRole('button', { name: /grassroots organizer/i }).click();
+  await page.waitForTimeout(100);
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(150);
+
+  await page.waitForSelector('text=Where do you stand?', { timeout: 4_000 });
+  await page.waitForSelector('[data-testid="ideology-compass"]', { timeout: 4_000 });
+}
+
+test.describe('ideology compass — redesign', () => {
+  test('renders the live orientation readout and no raw coordinates', async ({ page }) => {
+    await goToIdeologyStep(page);
+
+    const orientation = page.getByTestId('ideology-orientation');
+    await expect(orientation).toBeVisible();
+    // Default ideology is { x: 0, y: 0 } → "Centrist".
+    await expect(orientation).toHaveText(/centrist/i);
+
+    // No raw "x = …" / "y = …" coordinate exposure anywhere on the step.
+    await expect(page.locator('text=/x\\s*=\\s*-?\\d/')).toHaveCount(0);
+    await expect(page.locator('text=/y\\s*=\\s*-?\\d/')).toHaveCount(0);
+  });
+
+  test('plots historical reference figures', async ({ page }) => {
+    await goToIdeologyStep(page);
+
+    // Spot-check a representative spread of figures from the JSON file.
+    for (const id of ['fdr', 'reagan', 'sanders', 'thatcher', 'lincoln']) {
+      await expect(page.getByTestId(`ref-figure-${id}`)).toBeVisible();
+    }
+  });
+
+  test('shows a tooltip when hovering a reference figure', async ({ page }) => {
+    await goToIdeologyStep(page);
+
+    await page.getByTestId('ref-figure-reagan').hover();
+    const tip = page.getByRole('tooltip');
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText(/Ronald Reagan/i);
+  });
+
+  test('orientation label updates when the marker moves', async ({ page }) => {
+    await goToIdeologyStep(page);
+
+    const compass = page.getByTestId('ideology-compass');
+    await compass.focus();
+
+    // Drive the marker firmly into the right-authoritarian quadrant via
+    // keyboard nudges (Shift = 0.15 per press, default = 0.05).
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Shift+ArrowRight');
+      await page.keyboard.press('Shift+ArrowDown');
+    }
+
+    const orientation = page.getByTestId('ideology-orientation');
+    await expect(orientation).toHaveText(/right-authoritarian/i);
+  });
+});


### PR DESCRIPTION
# PR: Ideology Compass Redesign

## Summary
Rebuilds the political-spectrum picker as a larger, more communicative compass: drag/click/keyboard input, hidden raw coordinates, real-time orientation label, and ~20 historical reference figures the player can hover for context.

Stacks on top of `exp--auto-tooltip-terms` (PR #50). Base: `exp--auto-tooltip-terms`.

## What changed

### New
- `src/data/ideology/reference-figures.json` — 20 historical/contemporary figures (FDR, LBJ, JFK, Lincoln, Eisenhower, Nixon, Reagan, Carter, Obama, Clinton, Sanders, AOC, Thatcher, Goldwater, Wallace, Friedman, Chomsky, Mill, Rand, MLK), each with `id`, `name`, `era`, `x`, `y`.
- `src/renderer/components/ideologyLabel.ts` — pure utility mapping an `IdeologyPoint` to a human-readable orientation. Uses a 0.15 dead-zone, "Moderate" prefix below 0.4 magnitude, "Strong" prefix at/above 0.75.
- `src/renderer/components/ideologyLabel.test.ts` — 7 Vitest cases covering centrist, single-axis, compound, moderate, strong, and dead-zone behaviour.
- `tests/e2e/ideology-compass.spec.ts` — 4 new e2e cases × 3 viewports (`1280×720`, `1440×900`, `1920×1080`).

### Changed
- `src/renderer/components/IdeologyCompass.tsx` — full rewrite:
  - Larger by default (`size=320`), `360` in character creation.
  - Click-to-set, drag (Pointer Events + `setPointerCapture`), keyboard arrows (Shift = bigger step).
  - `role="slider"` + `aria-valuetext` reflecting the orientation label.
  - Quadrant tints (cool blue / warm red), inset quadrant labels (Lib-Left/Lib-Right/Auth-Left/Auth-Right), centre cross-hairs.
  - Reference figures rendered as `<button>` ghost markers (`tabIndex={-1}` to stay out of the page tab order); hover/focus pops a tooltip with name + era.
  - Live orientation label below the field (`data-testid="ideology-orientation"`, `aria-live="polite"`).
- `src/renderer/screens/CharacterCreation.tsx` — Step 3 now passes `size={360}`, drops the `x = … · y = …` font-mono line, and gains a one-paragraph hint about drag/keyboard input and the reference dots.
- `src/renderer/panels/CharacterPanel.tsx` — uses the compass at `size={240}` with `showReferenceFigures={false}` for compactness.
- `docs/about/CHANGELOG.md` — Unreleased entry added at top.

## Validation
- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm test` — **130/130 pass** (+7 from `ideologyLabel.test.ts`).
- `npx playwright test --workers=1 tests/e2e/ideology-compass.spec.ts tests/e2e/auto-tooltip.spec.ts tests/e2e/cards-and-tooltips.spec.ts` — **21/21 pass** across `1280×720`, `1440×900`, `1920×1080`.
  - Pre-existing `tests/e2e/accessibility.spec.ts` references a missing `tests/fixtures/a11y-fixture` module — unrelated to this PR; tracked separately.

## Self-review checklist
- [x] No emoji in UI files.
- [x] No `Math.random` in engine/systems/stores.
- [x] No `any`.
- [x] JSDoc on new exports; verbose inline comments.
- [x] Docs updated (CHANGELOG).
- [x] PR opened against `exp--auto-tooltip-terms`, not `development`.

## Screenshots
Live screenshots: re-run `npx playwright test tests/e2e/ideology-compass.spec.ts` and inspect `test-results/`. (Snapshot baselines intentionally not committed in this PR — visual baselines for the compass will be added once PR #50 lands and we rebase to `experimental`.)
