### PR TITLE
fix(ui): mobile portrait layout - drawer sidebar, safe-area, compact bars

### DIFF
--- a/docs/about/CHANGELOG.md
+++ b/docs/about/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Political Ascent are recorded here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mobile portrait layout** (`exp--mobile-portrait-fixes`). The 192px sidebar now collapses into an overlay drawer below the `md` breakpoint (toggled from a new TopBar hamburger), so the main panel keeps the full viewport width on phones. The Game shell applies `env(safe-area-inset-*)` padding and uses `100dvh` so the chrome doesn't clip under the Pixel notch / Dynamic Island / gesture bar. TopBar drops the "XP" suffix and "AP" caption below `sm`; BottomBar shrinks the speed buttons (40→36px) and abbreviates the long week footer; Dashboard KPI tiles use `text-2xl` on phones (vs. `text-data-lg` 32px on desktop) and truncate cleanly. New Pixel-7-portrait Playwright project + 3-test smoke (`tests/e2e/mobile-portrait.spec.ts`).
+
 ### Added
 
 - **Character panel optimisation + avatar presets + reference-figure relocation** (`exp--character-panel`, todo#6, todo#9, todo#10). New `<AvatarMedallion />` and `<AvatarPicker />` components plus a curated 8-entry preset registry under `src/data/avatars/` (icon-glyph medallions, no AI-generated portraits per AGENTS.md §2.9). Character creation now opens with a live avatar preview alongside the name field and a preset picker beneath the background tiles. The Character panel is rebuilt around a hero header (avatar + name + background blurb + change-avatar toggle), separate Stats / Traits / Progression cards, and a full-width ideology compass that now shows the historical reference figures (FDR, Reagan, Sanders, Thatcher, etc.). The dashboard mini-compass explicitly hides reference figures so the two surfaces don't compete. New `setAvatar` action on `characterStore`. 11 unit tests + 1 Playwright smoke (`tests/e2e/character-panel.spec.ts`).

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,6 +54,16 @@ export default defineConfig({
       name: "chromium-1920x1080",
       use: { ...devices["Desktop Chrome"], viewport: { width: 1920, height: 1080 } },
     },
+    // Mobile portrait — Pixel-class viewport. Used by the
+    // mobile-portrait.spec.ts smoke that guards the drawer sidebar,
+    // safe-area handling, and TopBar/BottomBar compaction below the
+    // `md` breakpoint.
+    {
+      name: "chromium-pixel-portrait",
+      use: {
+        ...devices["Pixel 7"],
+      },
+    },
   ],
 
   // Boot the Vite dev server before the suite and tear it down afterwards.

--- a/src/renderer/components/BottomBar.tsx
+++ b/src/renderer/components/BottomBar.tsx
@@ -79,11 +79,11 @@ function BottomBarImpl(): JSX.Element {
 
   return (
     <footer
-      className="h-[72px] bg-bg-secondary border-t border-rule px-5 grid items-center"
+      className="h-[72px] bg-bg-secondary border-t border-rule px-2 sm:px-5 grid items-center gap-1"
       style={{ gridTemplateColumns: '1fr auto 1fr' }}
     >
       {/* ─── LEFT: Speed controls ─────────────────────────────── */}
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1 sm:gap-1.5">
         {SPEEDS.map((s) => {
           // "Active" = the engine is currently running at this speed.
           // Pause is active both when explicitly paused and when speed
@@ -99,7 +99,10 @@ function BottomBarImpl(): JSX.Element {
               aria-pressed={isActive}
               onClick={() => TimeEngine.setSpeed(s.value)}
               className={
-                'w-10 h-10 rounded-sm flex items-center justify-center ' +
+                // Slightly smaller hit-target on phones so all four
+                // speeds fit alongside the centre week readout without
+                // pushing it off-axis.
+                'w-9 h-9 sm:w-10 sm:h-10 rounded-sm flex items-center justify-center ' +
                 'transition-all duration-instant active:translate-y-px ' +
                 (isActive
                   ? 'bg-accent-gold text-bg-primary shadow-glow-gold'
@@ -114,12 +117,17 @@ function BottomBarImpl(): JSX.Element {
       </div>
 
       {/* ─── CENTER: Week readout ─────────────────────────────── */}
-      <div className="flex flex-col items-center leading-none">
-        <span className="font-mono text-data-lg text-text-primary tabular-nums">
+      <div className="flex flex-col items-center leading-none min-w-0">
+        <span className="font-mono text-base sm:text-data-lg text-text-primary tabular-nums">
           WEEK {week}
         </span>
-        <span className="font-mono text-label uppercase tracking-widest text-text-muted mt-1">
+        {/* Long form on tablet+, abbreviated month on phones so the
+            line doesn't wrap into the speed buttons. */}
+        <span className="hidden sm:inline font-mono text-label uppercase tracking-widest text-text-muted mt-1">
           of 52 · {monthName} {date.year}
+        </span>
+        <span className="sm:hidden font-mono text-[0.625rem] uppercase tracking-widest text-text-muted mt-1">
+          of 52
         </span>
       </div>
 

--- a/src/renderer/components/Icon.tsx
+++ b/src/renderer/components/Icon.tsx
@@ -276,6 +276,15 @@ const ICONS = {
       <path d="M16 8V6a2 2 0 0 0 -2 -2H6a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
     </>
   ),
+  // Tabler "menu-2" — three horizontal bars. Mobile drawer toggle in
+  // the TopBar (`md:hidden`).
+  menu: (
+    <>
+      <path d="M4 6h16" />
+      <path d="M4 12h16" />
+      <path d="M4 18h16" />
+    </>
+  ),
 } as const satisfies Record<string, IconPath>;
 
 /** Public union of every valid icon id. Generated from the registry. */

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { useUIStore, type PanelId } from '@/store/uiStore';
 import { useRouter } from '../router';
 import { Icon, type IconName } from './Icon';
@@ -6,10 +6,18 @@ import { Icon, type IconName } from './Icon';
 /**
  * Sidebar — vertical panel navigation.
  *
- * The icons are drawn from `<Icon />` (Tabler, MIT) — previously this
- * file rendered ASCII glyphs (◎ § ⌇ ⧉ ♠ ✦ ✎) that were inconsistent in
- * weight and not legible at small sizes. Using a real icon font+stroke
- * brings the nav in line with `docs/guides/ICONS_AND_ASSETS.md`.
+ * Two display modes share the same nav list:
+ *
+ *   • Desktop / wide tablet (`md:` and up, ≥768px): the sidebar lives
+ *     inline as a 192px column to the left of the main panel.
+ *   • Mobile portrait (<768px): the sidebar is rendered as an overlay
+ *     drawer toggled from the TopBar hamburger. A scrim closes it on
+ *     tap; selecting a panel auto-closes it via the `setActivePanel`
+ *     reducer in `uiStore`.
+ *
+ * The drawer uses fixed positioning rather than CSS grid so its open
+ * state never reflows the rest of the shell — animation is GPU-cheap
+ * (transform + opacity only) and the main panel stays mounted.
  *
  * Active state is the same gold-fill treatment as a primary button, so
  * the active nav entry reads as "I am the current place" without
@@ -39,14 +47,19 @@ const PANELS: readonly PanelEntry[] = [
   { id: 'patch-notes', label: 'Patch Notes', icon: 'news' },
 ];
 
-function SidebarImpl(): JSX.Element {
+/**
+ * Render the actual nav list. Shared between the inline desktop column
+ * and the mobile drawer so the active-state styling and panel order
+ * stay identical across both surfaces.
+ */
+function NavList(): JSX.Element {
   const active = useUIStore((s) => s.activePanel);
   const setActivePanel = useUIStore((s) => s.setActivePanel);
   const navigate = useRouter((s) => s.navigate);
 
   return (
-    <aside className="w-48 bg-bg-secondary border-r border-rule flex flex-col py-3">
-      <nav className="flex-1 flex flex-col gap-0.5 px-2">
+    <>
+      <nav className="flex-1 flex flex-col gap-0.5 px-2 overflow-y-auto game-scroll">
         {PANELS.map((p) => {
           const isActive = active === p.id;
           return (
@@ -77,7 +90,67 @@ function SidebarImpl(): JSX.Element {
           <span className="font-mono text-label uppercase tracking-wider">Main menu</span>
         </button>
       </div>
-    </aside>
+    </>
+  );
+}
+
+function SidebarImpl(): JSX.Element {
+  const drawerOpen = useUIStore((s) => s.mobileSidebarOpen);
+  const setDrawerOpen = useUIStore((s) => s.setMobileSidebarOpen);
+
+  // Close the drawer on Escape — keyboard parity with modals.
+  useEffect(() => {
+    if (!drawerOpen) return;
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === 'Escape') setDrawerOpen(false);
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [drawerOpen, setDrawerOpen]);
+
+  return (
+    <>
+      {/* ─── Desktop inline column (md+) ────────────────────── */}
+      <aside
+        className="hidden md:flex w-48 bg-bg-secondary border-r border-rule flex-col py-3"
+        data-testid="sidebar-desktop"
+      >
+        <NavList />
+      </aside>
+
+      {/* ─── Mobile drawer (<md) ────────────────────────────── */}
+      {/* Scrim — covers the whole viewport including the top/bottom
+          bars so a tap anywhere outside the drawer dismisses it. */}
+      <button
+        type="button"
+        aria-hidden={!drawerOpen}
+        tabIndex={-1}
+        onClick={() => setDrawerOpen(false)}
+        className={
+          'md:hidden fixed inset-0 z-40 bg-black/60 transition-opacity duration-150 ' +
+          (drawerOpen ? 'opacity-100' : 'opacity-0 pointer-events-none')
+        }
+        data-testid="sidebar-scrim"
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation"
+        aria-hidden={!drawerOpen}
+        data-testid="sidebar-drawer"
+        className={
+          'md:hidden fixed top-0 left-0 z-50 h-full w-64 max-w-[80vw] ' +
+          'bg-bg-secondary border-r border-rule flex flex-col py-3 ' +
+          'transition-transform duration-300 ease-arrive ' +
+          (drawerOpen ? 'translate-x-0' : '-translate-x-full')
+        }
+        // Respect device safe-area on phones with rounded corners or
+        // gesture insets so the first nav entry is not clipped.
+        style={{ paddingTop: 'calc(env(safe-area-inset-top) + 0.75rem)' }}
+      >
+        <NavList />
+      </aside>
+    </>
   );
 }
 

--- a/src/renderer/components/TopBar.tsx
+++ b/src/renderer/components/TopBar.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { useGameStore } from '@/store/gameStore';
 import { useCharacterStore } from '@/store/characterStore';
+import { useUIStore } from '@/store/uiStore';
 import { ResourcePips } from './ResourcePips';
 import { ExtendedTooltip } from './tooltip';
 import { Icon } from './Icon';
@@ -51,23 +52,48 @@ function TopBarImpl(): JSX.Element {
   const level = useCharacterStore((s) => s.level);
   const xp = useCharacterStore((s) => s.xp);
 
+  const toggleSidebar = useUIStore((s) => s.toggleMobileSidebar);
+  const sidebarOpen = useUIStore((s) => s.mobileSidebarOpen);
+
   // 1-indexed month → 0-indexed lookup. Defensive clamp in case a save
   // file carries a bad value.
   const monthAbbrev = MONTH_ABBREV[Math.max(0, Math.min(11, date.month - 1))];
 
   return (
     <header
-      className="h-12 bg-bg-secondary border-b border-rule px-5 grid items-center"
+      className="h-12 bg-bg-secondary border-b border-rule px-2 sm:px-5 grid items-center gap-2"
       style={{ gridTemplateColumns: '1fr auto 1fr' }}
     >
-      {/* ─── LEFT: Identity ──────────────────────────────────── */}
-      <div className="flex items-baseline gap-3 min-w-0">
-        <span className="font-headline text-sm text-accent-gold truncate">
-          {name || 'Senator'}
-        </span>
-        <span className="font-mono text-label text-text-muted shrink-0">
-          LV {level} · {xp} XP
-        </span>
+      {/* ─── LEFT: Identity (and mobile hamburger) ──────────── */}
+      <div className="flex items-center gap-2 min-w-0">
+        {/* Hamburger — only visible below md, where the sidebar is a
+            drawer. Above md the sidebar is always inline so the toggle
+            would be a no-op. */}
+        <button
+          type="button"
+          onClick={toggleSidebar}
+          aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
+          aria-expanded={sidebarOpen}
+          aria-controls="sidebar-drawer"
+          data-testid="topbar-menu-button"
+          className="md:hidden w-9 h-9 flex items-center justify-center rounded-sm text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/60 transition-colors duration-instant shrink-0"
+        >
+          <Icon name="menu" size={20} aria-hidden />
+        </button>
+        <div className="flex items-baseline gap-2 sm:gap-3 min-w-0">
+          <span className="font-headline text-sm text-accent-gold truncate">
+            {name || 'Senator'}
+          </span>
+          {/* LV/XP is a tertiary readout — we keep it visible at all
+              widths but tighten the gap on phones so it doesn't push
+              the date readout out of the centre slot. */}
+          <span className="hidden sm:inline font-mono text-label text-text-muted shrink-0">
+            LV {level} · {xp} XP
+          </span>
+          <span className="sm:hidden font-mono text-label text-text-muted shrink-0">
+            LV {level}
+          </span>
+        </div>
       </div>
 
       {/* ─── CENTER: Date ────────────────────────────────────── */}
@@ -81,7 +107,7 @@ function TopBarImpl(): JSX.Element {
       </div>
 
       {/* ─── RIGHT: Resources ────────────────────────────────── */}
-      <div className="flex items-center justify-end gap-5">
+      <div className="flex items-center justify-end gap-2 sm:gap-5 min-w-0">
         <ExtendedTooltip term="political-capital">
           <div tabIndex={0} className="flex items-baseline gap-1.5 cursor-help focus:outline-none focus:ring-1 focus:ring-accent-gold rounded-sm">
             <span className="font-mono text-data text-accent-gold tabular-nums">
@@ -115,7 +141,10 @@ function TopBarImpl(): JSX.Element {
         <ExtendedTooltip term="action-points">
           <div tabIndex={0} className="flex items-center gap-1.5 cursor-help focus:outline-none focus:ring-1 focus:ring-accent-gold rounded-sm">
             <ResourcePips value={ap} max={apMax} tone="gold" label="Action Points" />
-            <span className="font-mono text-label text-text-muted">AP</span>
+            {/* "AP" caption is redundant on phones where the pip row
+                already telegraphs the resource; hide it below sm to
+                save horizontal real estate. */}
+            <span className="hidden sm:inline font-mono text-label text-text-muted">AP</span>
           </div>
         </ExtendedTooltip>
       </div>

--- a/src/renderer/panels/DashboardPanel.tsx
+++ b/src/renderer/panels/DashboardPanel.tsx
@@ -330,19 +330,19 @@ function Kpi({
   // navigation, focus rings, and screen-reader semantics come for free.
   const inner = (
     <>
-      <div className="flex items-center justify-between">
-        <span className="font-mono text-label uppercase tracking-widest text-text-muted">
+      <div className="flex items-center justify-between gap-1 min-w-0">
+        <span className="font-mono text-label uppercase tracking-wider sm:tracking-widest text-text-muted truncate">
           {label}
         </span>
         <span
-          className={`font-mono text-[0.625rem] ${TREND_CLS[trend]}`}
+          className={`font-mono text-[0.625rem] shrink-0 ${TREND_CLS[trend]}`}
           aria-hidden
         >
           {TREND_GLYPH[trend]}
         </span>
       </div>
       <div
-        className={`font-mono text-data-lg tabular-nums mt-1 leading-none ${TONE_CLS[tone]}`}
+        className={`font-mono text-2xl sm:text-data-lg tabular-nums mt-1 leading-none ${TONE_CLS[tone]} truncate`}
       >
         {value}
       </div>

--- a/src/renderer/screens/Game.tsx
+++ b/src/renderer/screens/Game.tsx
@@ -88,18 +88,32 @@ export function Game(): JSX.Element {
   return (
     // Three-row grid: the top and bottom rows have fixed pixel heights
     // (48px shell + 72px command strip) so the middle row inherits
-    // `1fr` and can scroll internally. `h-screen` guarantees the layout
-    // fills the viewport regardless of content height.
+    // `1fr` and can scroll internally. `100dvh` (with a `100vh`
+    // fallback baked in by Tailwind's `h-screen` if needed) handles the
+    // dynamic viewport on mobile so the bottom bar isn't hidden by the
+    // browser/system chrome on Android Chrome / iOS Safari.
+    //
+    // Safe-area insets (Pixel notch, Dynamic Island, gesture bars) are
+    // applied via CSS env() variables so the top bar isn't clipped and
+    // the bottom bar isn't pushed under the home indicator.
     <div
-      className="bg-bg-primary text-text-primary grid h-screen"
-      style={{ gridTemplateRows: '48px 1fr 72px' }}
+      className="bg-bg-primary text-text-primary grid"
+      style={{
+        gridTemplateRows: '48px 1fr 72px',
+        height: '100dvh',
+        minHeight: '100vh',
+        paddingTop: 'env(safe-area-inset-top)',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+        paddingLeft: 'env(safe-area-inset-left)',
+        paddingRight: 'env(safe-area-inset-right)',
+      }}
     >
       <TopBar />
       <div className="flex overflow-hidden">
         <Sidebar />
         <main
           key={activePanel}
-          className="flex-1 overflow-y-auto game-scroll p-5 md:p-6 animate-panel-enter"
+          className="flex-1 overflow-y-auto game-scroll p-3 sm:p-5 md:p-6 animate-panel-enter"
         >
           {activePanel === 'dashboard' && <DashboardPanel />}
           {activePanel === 'legislation' && <LegislationPanel />}

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -36,6 +36,16 @@ interface UIState {
   modals: ModalState[];
   toasts: ToastMessage[];
   contextPanelOpen: boolean;
+  /**
+   * Whether the mobile sidebar drawer is currently open.
+   *
+   * Below the `md` breakpoint (≤767px — phones in portrait, narrow
+   * tablets) the always-visible 192px sidebar would consume more than
+   * a third of the viewport. Instead the sidebar is rendered as an
+   * overlay drawer that the player toggles from the TopBar hamburger.
+   * Above `md` this flag is irrelevant — the sidebar is always inline.
+   */
+  mobileSidebarOpen: boolean;
 }
 
 interface UIStoreActions {
@@ -46,6 +56,8 @@ interface UIStoreActions {
   pushToast: (toast: Omit<ToastMessage, 'id' | 'createdAt'>) => void;
   dismissToast: (id: string) => void;
   setContextPanelOpen: (open: boolean) => void;
+  setMobileSidebarOpen: (open: boolean) => void;
+  toggleMobileSidebar: () => void;
 }
 
 type Store = UIState & UIStoreActions;
@@ -56,10 +68,15 @@ export const useUIStore = create<Store>()(
     modals: [],
     toasts: [],
     contextPanelOpen: true,
+    mobileSidebarOpen: false,
 
     setActivePanel: (panel) =>
       set((s) => {
         s.activePanel = panel;
+        // Selecting a panel from the mobile drawer should close it so the
+        // freshly-rendered panel is fully visible. On md+ this flag has
+        // no rendered effect, so the assignment is harmless.
+        s.mobileSidebarOpen = false;
       }),
 
     openModal: (modal) =>
@@ -95,6 +112,16 @@ export const useUIStore = create<Store>()(
     setContextPanelOpen: (open) =>
       set((s) => {
         s.contextPanelOpen = open;
+      }),
+
+    setMobileSidebarOpen: (open) =>
+      set((s) => {
+        s.mobileSidebarOpen = open;
+      }),
+
+    toggleMobileSidebar: () =>
+      set((s) => {
+        s.mobileSidebarOpen = !s.mobileSidebarOpen;
       }),
   })),
 );

--- a/tests/e2e/mobile-portrait.spec.ts
+++ b/tests/e2e/mobile-portrait.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Mobile portrait smoke (PR — exp--mobile-portrait-fixes).
+ *
+ * Pixel-class portrait viewports surfaced three regressions in the
+ * 0.1.0-alpha.1-exp.20260428 prerelease APK:
+ *
+ *   1. The 192px sidebar consumed more than a third of the viewport
+ *      and squeezed every panel into uselessness.
+ *   2. KPI tile values clipped (`UNEMPLOYME`, `2.10%` cut off,
+ *      `$1.7T` cut off) because the main panel was too narrow.
+ *   3. The TopBar status bar overlapped the system status row, and
+ *      the BottomBar week-readout collided with the speed buttons.
+ *
+ * The fixes:
+ *
+ *   • Sidebar renders as an overlay drawer below `md` (toggled from
+ *     a hamburger button on the TopBar). The desktop column is gated
+ *     by `hidden md:flex` so the main panel keeps the full viewport
+ *     width on phones.
+ *   • TopBar applies `env(safe-area-inset-*)` padding via the Game
+ *     shell, hides "XP" and the "AP" caption below `sm`, and tightens
+ *     gaps so the three zones fit on a 360px-wide line.
+ *   • BottomBar shrinks the speed buttons (40→36 px) and abbreviates
+ *     the long "of 52 · January 2025" footer below `sm`.
+ *   • Dashboard KPI value font drops from `text-data-lg` (32px) to
+ *     `text-2xl` (24px) on phones; values truncate cleanly.
+ *
+ * This spec runs on the `chromium-pixel-portrait` project (Pixel 7,
+ * 412×915 portrait) so the breakpoint behaviour is exercised against
+ * a realistic device profile, not just a custom desktop viewport.
+ */
+
+/**
+ * Walk character creation with default choices and land on the
+ * dashboard. Mirrors `character-panel.spec.ts::goToGame` but skipping
+ * the avatar picker to keep this spec focused on layout, not content.
+ */
+async function goToGame(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  await page.getByRole('button', { name: /new game/i }).click();
+  await page.waitForSelector('text=Build Your Candidate', { timeout: 8_000 });
+
+  await page.fill('input[placeholder*="Jordan"]', 'Alex Rivera');
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(200);
+
+  await page.waitForSelector('text=Core Stats', { timeout: 4_000 });
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(200);
+
+  await page.getByText(/Pick 1.{1,3}3/).waitFor({ timeout: 4_000 });
+  await page.getByRole('button', { name: /grassroots organizer/i }).click();
+  await page.waitForTimeout(150);
+  await page.getByRole('button', { name: /^next$/i }).click();
+  await page.waitForTimeout(200);
+
+  await page.waitForSelector('text=Where do you stand?', { timeout: 4_000 });
+  await page.getByRole('button', { name: /choose scenario/i }).click();
+  await page.waitForTimeout(300);
+
+  await page.waitForSelector('text=Choose Your Arena', { timeout: 6_000 });
+  await page.getByRole('button', { name: /^begin$/i }).first().click();
+  await page.waitForTimeout(400);
+
+  // Dashboard text appears as a nav entry; wait for the KPI strip to
+  // be the indicator we have actually landed in-game.
+  await page.locator('[data-testid="kpi-approval"]').first().waitFor({ timeout: 8_000 });
+}
+
+test.describe('mobile portrait', () => {
+  test('sidebar is hidden by default and toggled via the hamburger', async ({ page }) => {
+    await goToGame(page);
+
+    // Inline desktop sidebar must be hidden on phones.
+    const desktopSidebar = page.locator('[data-testid="sidebar-desktop"]');
+    await expect(desktopSidebar).toBeHidden();
+
+    // Drawer is rendered but off-screen (translate-x-full) until toggled.
+    const drawer = page.locator('[data-testid="sidebar-drawer"]');
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true');
+
+    // Hamburger opens the drawer.
+    const menuButton = page.locator('[data-testid="topbar-menu-button"]');
+    await expect(menuButton).toBeVisible();
+    await menuButton.click();
+    await expect(drawer).toHaveAttribute('aria-hidden', 'false');
+
+    // Tapping a panel inside the drawer auto-closes it.
+    await drawer.getByRole('button', { name: /^character$/i }).click();
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('KPI strip stays inside the viewport with no horizontal overflow', async ({ page }) => {
+    await goToGame(page);
+
+    // The main scrolling panel should not generate a horizontal scrollbar
+    // on phones — every KPI value must render on its allotted half-width.
+    const overflowsX = await page.evaluate(() => {
+      const main = document.querySelector('main');
+      if (!main) return true;
+      return main.scrollWidth > main.clientWidth + 1;
+    });
+    expect(overflowsX).toBe(false);
+
+    // Spot-check the GDP tile — its value used to clip on the prerelease.
+    const gdp = page.locator('[data-testid="kpi-gdp"]');
+    await expect(gdp).toBeVisible();
+    const text = (await gdp.textContent()) ?? '';
+    // Either "%" or "Pp" should be present (different scenarios produce
+    // different starting GDP signs); we just want to know the trailing
+    // character actually rendered rather than being cut by overflow.
+    expect(/%|pp/i.test(text)).toBe(true);
+  });
+
+  test('BottomBar speed controls and week readout coexist without clipping', async ({ page }) => {
+    await goToGame(page);
+
+    const footer = page.locator('footer');
+    await expect(footer).toBeVisible();
+
+    const pause = footer.getByRole('button', { name: /pause/i });
+    const fast = footer.getByRole('button', { name: /^fast$/i });
+    await expect(pause).toBeVisible();
+    await expect(fast).toBeVisible();
+
+    // The week readout text must be present (might wrap but must not be
+    // hidden behind the speed-button column).
+    await expect(footer.getByText(/^WEEK\s+\d+/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Hotfix for the mobile portrait regressions that surfaced on the Pixel-class APK prerelease (visible in the screenshot the Lead Director attached: sidebar dominating the viewport, KPI values clipping, top/bottom bars overlapping system chrome).

**What's in**
- Sidebar renders as overlay drawer below md (hamburger in TopBar). Desktop column gated by hidden md:flex. setActivePanel auto-closes the drawer.
- Game shell applies env(safe-area-inset-*) padding and uses 100dvh + 100vh fallback.
- TopBar hides XP suffix and AP caption below sm; tighter gaps; new menu icon.
- BottomBar shrinks speed buttons (40 to 36 px) and abbreviates long week footer below sm.
- Dashboard KPI: text-2xl on phones, text-data-lg on desktop; values truncate cleanly.

**Tests**
- New chromium-pixel-portrait Playwright project (Pixel 7).
- New mobile-portrait.spec.ts with 3 tests: drawer toggle, no horizontal overflow, BottomBar coexistence. All pass.
- character-panel.spec.ts (1280x720) still passes.
- Vitest 203 passing. Lint/typecheck clean.

**Release**
- Debug APK published as https://github.com/ScottyVenable/Political-Ascent/releases/tag/v0.1.0-alpha.1-exp.20260428b targeting this branch.