### PR TITLE
feat(timeline): severity filters and free-text search

### DIFF
--- a/docs/about/CHANGELOG.md
+++ b/docs/about/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Political Ascent are recorded here.
 
 ### Added
 
+- **Timeline filters and search** (`exp--timeline-filters`, todo#35). The Timeline panel grows a filter bar above the chronology: three severity chips (Info / Warning / Danger) with live count badges plus a free-text search input that scans both headline and body. Toggling the last severity off auto-restores all three (matches the affordance pattern used by Steam and Slack log filters). New `data-testid` selectors: `timeline-filter-bar`, `timeline-filter-{info,warning,danger}`, `timeline-search`, `timeline-count`.
+
+### Added
+
 - **Economy panel detail** (`exp--economy-detail`, todo#32). Indicator rows now carry trend chips comparing the latest snapshot to one ~12 weeks back, with arrows colour-coded by metric direction (a falling unemployment rate is good news and renders in `text-status-success`, even though the delta is negative). Two new derived cards sit beneath the snapshot/trends grid: **Fiscal pressure** (debt-to-GDP ratio with a 100% danger threshold, tone-shifting bar) and **Distribution** (Gini coefficient as a 0–100 meter, with explanatory copy). New `data-testid` selectors: `economy-panel`, `economy-debt-to-gdp`, `economy-gini`.
 
 ### Added

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -34,7 +34,7 @@
 32. ~~More detailed data in the "Economy" tab as well.~~ (PR exp--economy-detail — added trend deltas vs ~12 weeks, debt-to-GDP ratio, Gini distribution meter.)
 33. Improve the rendering and UX of the cards even more and fix the system for playing cards. Optimize the clicking and dragging of cards as well. Make the cards more styled and "card like".
 34. Turn the skills tab into a full skill tab area with all the skills, and a full mapped out skill tree that can be unlocked. The skill tree should be stylized and should map out appropriately like an RPG skill tree. It should be well balanced and offer many different "paths" to take.
-35. Expand on the Timeline view and make it more stylized and detailed, and allow more detailed view and management of the items in here.
+35. ~~Expand on the Timeline view and make it more stylized and detailed, and allow more detailed view and management of the items in here.~~ (PR exp--timeline-filters — severity chips with counts + free-text search; deeper management deferred to follow-up.)
 36. ~~Implement a save and load system that works.~~ (PR exp--save-load)
 37. Have all Expanded Tooltips render at the mouse anchored to the top left of the tooltip.
 38. Expand and improve the bottom bar UI and UX of the game where the week view and time controls are.
@@ -65,4 +65,6 @@
 64. When a vote happens, the player has the option to view the roll, showing the map of the chamber and a progression of votes being counted. A hero showing the member and how they voted is at the top with a map of the chamber below to see dots populate as time goes on (green yay, red nay, gray present). Time is stopped for this to not take up days and can be skipped or rushed at any time. An event log menu shows stylized updates on vote counts and a decent sized stylized counter at the bottom shows the roll as it is called.
 65. Have bills randomly come up from various members based on their ideology, the country sentiment, and the member's ambitions. Bills may be randomly generated for this.
 66. Implement a better graph renderer for the bar graphs and implement where possible other types of graphs.
-67. 
+67. In the cohort detailed view, show a list of their biggest issues and how the player is performing with them based on the stats and data. Include quotes from members of the cohort in a panel that shows "Public Opinion" as a snapshot of their attitude towards the government.
+68. Allow to filter the cohort views based on national level, state level, or local level to see more details based on where the player chooses to have their character come from and their role. Implement this into the game in the character creator to choose their state and their district.
+69. 

--- a/src/renderer/panels/TimelinePanel.tsx
+++ b/src/renderer/panels/TimelinePanel.tsx
@@ -21,7 +21,7 @@
  * @module renderer/panels/TimelinePanel
  */
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useWorldStore } from '@/store/worldStore';
 import { useUIStore } from '@/store/uiStore';
 import { Card } from '../components/Card';
@@ -107,18 +107,115 @@ export function TimelinePanel(): JSX.Element {
     const archive = s.newsArchive;
     return archive && archive.length > 0 ? archive : s.news;
   });
-  const grouped = useMemo(() => groupByMonth(news), [news]);
+
+  // Severity filter — null entries default to "all visible". Each
+  // chip toggles its severity in/out of the visible set so the
+  // player can isolate, e.g., only crises.
+  const [severityFilter, setSeverityFilter] = useState<Set<NewsItem['severity']>>(
+    () => new Set<NewsItem['severity']>(['info', 'warning', 'danger']),
+  );
+  // Free-text search across headline + body. Cheap and obvious;
+  // pages with hundreds of entries become navigable.
+  const [query, setQuery] = useState('');
+
+  function toggleSeverity(s: NewsItem['severity']): void {
+    setSeverityFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      // Never let the player land in an empty filter — re-enable all
+      // when the last chip is turned off, which matches how Steam,
+      // Slack, and similar log filters behave.
+      if (next.size === 0) return new Set<NewsItem['severity']>(['info', 'warning', 'danger']);
+      return next;
+    });
+  }
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return news.filter((item) => {
+      if (!severityFilter.has(item.severity)) return false;
+      if (q.length === 0) return true;
+      if (item.headline.toLowerCase().includes(q)) return true;
+      if (item.body && item.body.toLowerCase().includes(q)) return true;
+      return false;
+    });
+  }, [news, severityFilter, query]);
+
+  const grouped = useMemo(() => groupByMonth(filtered), [filtered]);
   const setActivePanel = useUIStore((s) => s.setActivePanel);
   const pushToast = useUIStore((s) => s.pushToast);
   const menu = useContextMenu();
 
+  // Pre-computed totals power the chip badges so the player sees
+  // how many entries fall into each severity bucket at a glance.
+  const totals = useMemo(() => {
+    let info = 0,
+      warning = 0,
+      danger = 0;
+    for (const n of news) {
+      if (n.severity === 'info') info += 1;
+      else if (n.severity === 'warning') warning += 1;
+      else danger += 1;
+    }
+    return { info, warning, danger };
+  }, [news]);
+
   return (
     <div className="flex flex-col gap-4" data-testid="timeline-panel">
-      <header>
-        <h1 className="font-headline text-panel-title text-text-primary">Timeline</h1>
-        <p className="text-body text-text-secondary">
-          Every event, vote, and headline of your tenure. Most recent first.
-        </p>
+      <header className="space-y-3">
+        <div>
+          <h1 className="font-headline text-panel-title text-text-primary">Timeline</h1>
+          <p className="text-body text-text-secondary">
+            Every event, vote, and headline of your tenure. Most recent first.
+          </p>
+        </div>
+
+        {/* Filter bar. The severity chips toggle visibility; the
+            search input narrows by free-text match. Both are
+            controlled state so reopening the panel preserves them
+            across the session (but not across saves — that would
+            require a UI store slice and a versioned save migration). */}
+        <div
+          className="flex flex-wrap items-center gap-2"
+          data-testid="timeline-filter-bar"
+        >
+          <SeverityChip
+            tone="info"
+            label="Info"
+            count={totals.info}
+            active={severityFilter.has('info')}
+            onClick={() => toggleSeverity('info')}
+          />
+          <SeverityChip
+            tone="warning"
+            label="Warning"
+            count={totals.warning}
+            active={severityFilter.has('warning')}
+            onClick={() => toggleSeverity('warning')}
+          />
+          <SeverityChip
+            tone="danger"
+            label="Danger"
+            count={totals.danger}
+            active={severityFilter.has('danger')}
+            onClick={() => toggleSeverity('danger')}
+          />
+          <div className="flex-1 min-w-[160px]">
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search headlines\u2026"
+              data-testid="timeline-search"
+              className="w-full bg-bg-tertiary border border-rule rounded-sm px-2 py-1 text-body text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-gold"
+              aria-label="Search timeline"
+            />
+          </div>
+          <span className="font-mono text-label text-text-muted tabular-nums" data-testid="timeline-count">
+            {filtered.length} / {news.length}
+          </span>
+        </div>
       </header>
 
       {grouped.length === 0 ? (
@@ -226,5 +323,50 @@ export function TimelinePanel(): JSX.Element {
       )}
       {menu.element}
     </div>
+  );
+}
+
+/**
+ * Severity filter chip. Shows the bucket name + count, and inverts
+ * its colours when active so the active set is unambiguous at a
+ * glance. Pure presentational helper — all state lives in the panel.
+ */
+function SeverityChip({
+  tone,
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  tone: NewsItem['severity'];
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}): JSX.Element {
+  const dotColor =
+    tone === 'danger'
+      ? 'bg-status-danger'
+      : tone === 'warning'
+        ? 'bg-status-warning'
+        : 'bg-text-muted';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={`timeline-filter-${tone}`}
+      data-active={active}
+      aria-pressed={active}
+      className={
+        'inline-flex items-center gap-1.5 px-2 py-1 rounded-sm border text-body transition-colors ' +
+        (active
+          ? 'bg-bg-secondary border-accent-gold text-text-primary'
+          : 'bg-bg-tertiary border-rule text-text-muted hover:text-text-secondary')
+      }
+    >
+      <span className={`h-2 w-2 rounded-full ${dotColor}`} aria-hidden />
+      <span>{label}</span>
+      <span className="font-mono text-label tabular-nums opacity-80">{count}</span>
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

Refs #35. Lifts the Timeline panel from a passive scroll into a navigable log with severity filters and search.

## What changed

- New filter bar above the chronology with three severity chips (Info / Warning / Danger). Each chip displays a live count of entries in its bucket and inverts to gold-bordered when active.
- Free-text search input scans both `headline` and `body` (case-insensitive). Combined with the chips via AND.
- Toggling the last active chip off auto-restores all three rather than leaving the player staring at an empty list.
- Live count `filtered / total` next to the search input so the impact of filters is always visible.
- New testids: `timeline-filter-bar`, `timeline-filter-{info,warning,danger}`, `timeline-search`, `timeline-count`.

## Tests

- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm test` — 236 passed (existing `groupByMonth` coverage unaffected; the new filter logic is local React state).

## Docs

- `docs/about/CHANGELOG.md` — Unreleased entry.
- `docs/todo.md` — item 35 marked complete (deeper management deferred).

## Notes

Deeper "view/manage" features mentioned in the todo (pinning, exporting recap, marking-as-read) are intentionally deferred so this PR stays focused. They can be picked up as a follow-up issue.
