### PR TITLE
fix(save): preserve store actions on load + tidy todo#81

### DIFF
--- a/docs/about/CHANGELOG.md
+++ b/docs/about/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Political Ascent are recorded here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Save/load no longer wipes Zustand actions** (`exp--todo-tidy`, todo#81). `applySavePayload` was calling `useGameStore.setState(snapshot, true)` which Zustand interprets as full-replace and silently dropped the bound action methods (`setSpeed`, `setPaused`, etc.). On the very next render `GameEngine.startClock` would crash with `game.setSpeed is not a function`. Switched to merge-mode (`setState(snapshot)` without the second arg) so action methods survive the load while every persisted data field is still overwritten by the snapshot. Test coverage held at 7/7 because the tests only check data round-trip; the bug was action-binding which production code exercises but the tests didn't.
+- **`dataLoader` warning** (`exp--todo-tidy`, todo#81 cluster). The legislation glob `/src/data/legislation/*.json` matched `policy-modules.json` from the draft-legislation PR and tried to validate it as a `BillTemplate`, logging `skipping invalid file` on every boot. Moved the file to `src/data/legislation/modules/policy-modules.json` (out of the bills glob) and updated the import path in `DraftLegislationScreen`.
+
 ### Added
 
 - **Bottom bar polish + mobile portrait sweep** (`exp--bottom-bar-polish`, todo#23 + todo#38). Bottom bar gets a richer command strip: speed buttons render as a true segmented `radiogroup` (rounded-l on Pause, rounded-r on 4&times;, square middles, gold-glow on the active member), keyboard-shortcut chips (`Space`, `1`, `2`, `4`) render under each speed on tablet+, the centre week readout grows a slim year-progress bar (1px on phones, 2px on tablet+, gold), the right-side cluster now shows a vertical divider before the destructive Menu button, and the footer honours `env(safe-area-inset-bottom)` so the Pixel home indicator doesn't clip controls. New `data-testid` selectors: `bottombar`, `bottombar-speed`, `bottombar-speed-{0|1|2|4}`, `bottombar-week`, `bottombar-year-progress`. Mobile portrait spec extended to verify Population / Economy / Timeline / Skills panels layout cleanly in a Pixel-class viewport with no horizontal overflow.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -67,4 +67,21 @@
 66. Implement a better graph renderer for the bar graphs and implement where possible other types of graphs.
 67. In the cohort detailed view, show a list of their biggest issues and how the player is performing with them based on the stats and data. Include quotes from members of the cohort in a panel that shows "Public Opinion" as a snapshot of their attitude towards the government.
 68. Allow to filter the cohort views based on national level, state level, or local level to see more details based on where the player chooses to have their character come from and their role. Implement this into the game in the character creator to choose their state and their district.
-69. 
+69. Eliminate the both chambers view and only have the one at a time. Also make the member detail show up as a tooltip at the mouse when hovering over a seat. Then on the right side there should be a panel list of all the members with search functions, filter options, sort options and when typing or selecting filters, the chamber view adjusts in real time lowering the opacity of members not applicable and leaving the ones who are. Allow a toggle switch to either hide the members on filter selection or dim them.
+70. Implement a system for tracking and displaying the player's interactions with members of Congress, including meetings, conversations, and votes. This would provide players with a clear sense of their relationships and help them plan their next moves strategically.
+71. Implement a system for tracking and displaying the player's progress on various political goals and objectives, including bills passed, public approval, and faction support. This would provide players with a clear sense of their achievements and help them plan their next moves strategically.
+72. Implement a system for tracking and displaying the player's/NPCs relationships with various political factions and interest groups, including their level of support and influence. This would allow players to make informed decisions about which factions to align with and how to navigate the complex web of political alliances in the game.
+73. Have a breakdown on the bill creation showing where the opposition from the bill is coming from on certain provisions. Expand on this system more by making the Draft New menu have the player creaete the name of the bill (or generate one), choose the category, and various other adjustments before going in the adding of provisions and drafting the bill. More provisions and features will be added based on upgrades, cards, traits, ideology, feedback from constituants, and research gathered from the players team (which would be a new menu to manage staff and direct them based on role).
+74. In the Character screen, track the player characters personal funds and implement ways to get more.
+75. Find all data tags rendered in the game and make sure to render them to be better fitting in the game instead of just the name of the variable.
+76. Lock scrolling when a modal/popup is up.
+77. Make it so nested Expanded Tooltips can be locked at the same time, but seperate non parent ones cannot.
+78. Add an autosave system
+79. Hide the top tool bar "File/View/etc" from the game.
+80. Add a setting for enabling fullscreen and it being consistent when opening the game again.
+81. ~~Fix error when loading a save (`game.setSpeed is not a function` from `startClock` after applying snapshot, plus `dataLoader` warning `skipping invalid file /src/data/legislation/policy-modules.json`).~~ Both fixed: `applySavePayload` now merges into the live store rather than full-replacing (action methods preserved), and `policy-modules.json` moved to `src/data/legislation/modules/` so the bills glob no longer picks it up.
+82. (no entry — original numbering jumped from 81 to 83 in source)
+83. Fix vote counts not showing up when focusing on a house/senate member.
+84. Show an effects modal when playing a card that tell's you what it did.
+85. Show a modal when a vote finishes instead of just a notification. Stylaized to show the Yay's and Nay's and a breakdown that the player can navigate before dismissing it.
+86. 

--- a/src/engine/SaveSystem.ts
+++ b/src/engine/SaveSystem.ts
@@ -268,14 +268,17 @@ export async function deleteSave(slotId: string): Promise<boolean> {
  * the Game screen) — this function only restores state.
  */
 export function applySavePayload(payload: SavePayload): void {
-  // Use replace=true so we don't merge stale keys from the previous
-  // run. Action methods on the live store are preserved by Zustand's
-  // setState contract regardless of the snapshot shape. The cast is
-  // intentional: the snapshot is `unknown` until the schema-version
-  // gate in `isValidPayload` clears it.
-  useGameStore.setState(payload.stores.game as object, true);
-  useCharacterStore.setState(payload.stores.character as object, true);
-  useWorldStore.setState(payload.stores.world as object, true);
+  // Merge (replace=false) rather than full-replace. Zustand's
+  // `setState(state, true)` wipes everything — including the action
+  // methods bound by the store factory — which would leave callers
+  // calling `game.setSpeed(...)` against a plain data object after a
+  // load. By merging instead we keep the action surface intact while
+  // every persisted data field is overwritten by the snapshot. The
+  // cast is intentional: the snapshot is `unknown` until the
+  // schema-version gate in `isValidPayload` clears it.
+  useGameStore.setState(payload.stores.game as object);
+  useCharacterStore.setState(payload.stores.character as object);
+  useWorldStore.setState(payload.stores.world as object);
   log.info('save applied', { meta: payload.meta });
 }
 


### PR DESCRIPTION
## Summary

Two-part patch:

1. **Critical save/load fix.** `applySavePayload` was calling `useGameStore.setState(snapshot, true)` — Zustand's full-replace mode — which silently dropped every action method bound by the store factory. The first render after a load then crashed with `TypeError: game.setSpeed is not a function` from `GameEngine.startClock`. Switched to merge mode so action methods survive the load.
2. **Docs cleanup.** Collapsed the multi-screen JSON stack-trace dump under todo#81 down to a one-line resolution note now that both halves of that bug are fixed (this PR + the policy-modules relocation amended into `exp--draft-legislation`).

## Why it matters

Without this fix, the entire load flow is broken in production: every save the player tries to load lands them on a black error-boundary screen. The fact that 7/7 SaveSystem unit tests passed while production was broken is a coverage gap (tests verified data round-trip; the bug was action-binding which only surfaces when production code calls `game.setSpeed(...)` after load).

## Files

- `src/engine/SaveSystem.ts` — drop the `, true` on three `setState` calls + rewrite the comment to explain why merge mode is required.
- `docs/about/CHANGELOG.md` — record the fix under Unreleased > Fixed.
- `docs/todo.md` — collapse the #81 dump.

## Linked

- Refs todo#81 (closed by this PR + the policy-modules relocation in #80).

## Tests

- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npx vitest run src/engine/SaveSystem.test.ts` — 7/7 pass.
- `npx vitest run` — 236/236 pass.

## Risk

Low. Merge mode keeps every data key from the snapshot and only stops Zustand from dropping the bound actions. The only behavioural difference vs. replace mode is that keys present on the live store but absent from the snapshot are preserved — which for our store shapes means action methods, exactly what we want.

## Stack position

This is the tail of the in-flight stack:

`exp--population-focus` → `exp--economy-detail` → `exp--timeline-filters` → `exp--skill-tree` → `exp--draft-legislation` → `exp--bottom-bar-polish` → **`exp--todo-tidy`** → `experimental`.

When the chain merges forward, this fix lands with the rest.
