### PR TITLE
feat(congress): single-chamber view, member search, vote-count fix, vote-result modal

### DIFF
--- a/src/renderer/components/Hemicycle.tsx
+++ b/src/renderer/components/Hemicycle.tsx
@@ -50,8 +50,16 @@ export interface HemicycleProps {
   onSelect?: (l: Legislator) => void;
   /** Currently highlighted legislator id, if any. */
   highlightId?: string;
-  /** Hover callback; emits null on leave. */
-  onHover?: (l: Legislator | null) => void;
+  /** Hover callback with client-space cursor coordinates (for floating tooltip). */
+  onHoverPos?: (l: Legislator | null, x: number, y: number) => void;
+  /**
+   * Set of legislator ids that should be dimmed (reduced opacity) in the
+   * chart. Seats not in this set remain fully opaque. Used by the member
+   * list search/filter to de-emphasise non-matching members without hiding
+   * them entirely — matching the GDD §14 "context without clutter" goal.
+   * When the set is empty or undefined, all seats are fully opaque.
+   */
+  dimmedIds?: ReadonlySet<string>;
   className?: string;
 }
 
@@ -177,8 +185,9 @@ function HemicycleImpl({
   legislators,
   width = 520,
   onSelect,
-  onHover,
+  onHoverPos,
   highlightId,
+  dimmedIds,
   className = '',
 }: HemicycleProps): JSX.Element {
   const { seats, viewHeight } = useMemo(
@@ -198,6 +207,8 @@ function HemicycleImpl({
         const fill = PARTY_FILL[party] ?? '#5F6158';
         const stroke = PARTY_STROKE[party] ?? '#3A3B36';
         const isHighlighted = highlightId === (s.legislator.id as unknown as string);
+        const isDimmed = dimmedIds !== undefined && dimmedIds.size > 0 &&
+          dimmedIds.has(s.legislator.id as unknown as string);
         return (
           <circle
             key={s.legislator.id as unknown as string}
@@ -207,10 +218,15 @@ function HemicycleImpl({
             fill={fill}
             stroke={isHighlighted ? '#D8D6CC' : stroke}
             strokeWidth={isHighlighted ? 1.5 : 0.5}
-            style={{ cursor: onSelect ? 'pointer' : 'default' }}
+            opacity={isDimmed ? 0.18 : 1}
+            style={{ cursor: onSelect ? 'pointer' : 'default', transition: 'opacity 0.15s' }}
             onClick={onSelect ? () => onSelect(s.legislator) : undefined}
-            onMouseEnter={onHover ? () => onHover(s.legislator) : undefined}
-            onMouseLeave={onHover ? () => onHover(null) : undefined}
+            onMouseEnter={
+              onHoverPos
+                ? (e) => onHoverPos(s.legislator, e.clientX, e.clientY)
+                : undefined
+            }
+            onMouseLeave={onHoverPos ? (e) => onHoverPos(null, e.clientX, e.clientY) : undefined}
           >
             <title>
               {s.legislator.name} ({party}-{s.legislator.state}

--- a/src/renderer/components/Icon.tsx
+++ b/src/renderer/components/Icon.tsx
@@ -276,6 +276,22 @@ const ICONS = {
       <path d="M16 8V6a2 2 0 0 0 -2 -2H6a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
     </>
   ),
+  // Tabler "eye" — show / visibility. Used by the Congress member-list
+  // dim/hide toggle (todo#69).
+  eye: (
+    <>
+      <circle cx="12" cy="12" r="2" />
+      <path d="M22 12c-2.667 4.667 -6 7 -10 7s-7.333 -2.333 -10 -7c2.667 -4.667 6 -7 10 -7s7.333 2.333 10 7" />
+    </>
+  ),
+  // Tabler "eye-off" — hide / visibility disabled. Congress dim→hide toggle.
+  'eye-off': (
+    <>
+      <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />
+      <path d="M16.681 16.673A8.717 8.717 0 0 1 12 18c-3.6 0 -6.6 -2 -9 -6c1.272 -2.12 2.712 -3.678 4.32 -4.674M19.5 14.3c.222 -.457 .432 -.94 .629 -1.45a2 2 0 0 0 .371 -3.85" />
+      <path d="M3 3l18 18" />
+    </>
+  ),
   // Tabler "menu-2" — three horizontal bars. Mobile drawer toggle in
   // the TopBar (`md:hidden`).
   menu: (

--- a/src/renderer/panels/CongressPanel.tsx
+++ b/src/renderer/panels/CongressPanel.tsx
@@ -1,27 +1,34 @@
 /**
  * CongressPanel — the chamber floor.
  *
- * Redesign goals (UI_GAME_FEEL_PROPOSAL §8.4 / issue #41):
- *   - Show Congress as two chambers stacked vertically, each rendered
- *     as a semicircular hemicycle (see `Hemicycle.tsx`). This replaces
- *     the previous flat grid of coloured dots.
- *   - Above each hemicycle, a "plinth" header shows total seats,
- *     majority threshold, and a stacked party-ratio bar that lets the
- *     player read the coalition shape at a glance.
- *   - Clicking a seat opens a detail drawer alongside the chart
- *     (bottom strip on narrow screens, side rail on wide).
- *   - Party filter styled with the Button component so it no longer
- *     looks like raw inline CSS.
+ * Redesign pass (todo#69, April 2026):
+ *   - Eliminated the "both chambers" view. Players choose Senate or House
+ *     with a two-tab strip; one chamber owns the entire viewport at a time,
+ *     giving the hemicycle more room and making the member list readable.
+ *   - Left column: plinth header + hemicycle. Right column: scrollable
+ *     member roster with real-time search, party filter, sort options, and
+ *     a hide/dim toggle. Typing in the search box updates the hemicycle
+ *     in real time — non-matching seats fade to ~18% opacity so spatial
+ *     context (left/right arc position) is preserved while matched members
+ *     are visually prominent.
+ *   - Hovering a seat shows a floating tooltip anchored at the cursor.
+ *   - Clicking a seat or a member row opens the full MemberModal.
  *
- * Performance notes:
- *   - `Hemicycle` is memoized and only recomputes when its legislator
- *     list identity changes. Store selectors return the raw array
- *     reference so unrelated world updates do not trigger a re-layout
- *     of 535 seats.
- *   - Filtering to a single party typically cuts the working set in
- *     half so the re-layout on filter-toggle is cheap.
+ * Vote count fix (todo#83): vote counts now populate because
+ * `LegislationSystem.resolveVote` records each senator's individual vote
+ * into `legislator.votingHistory` immediately after the roll-call.
+ *
+ * Performance:
+ *   - `Hemicycle` is memoized and recomputes only when the legislators
+ *     list identity changes. The dimmedIds Set is rebuilt by useMemo
+ *     whenever search/filter/chamber state changes.
+ *   - Member list is a windowed `<ul>` in CSS — no virtualizer needed
+ *     for 100 senators; for 435 representatives this is borderline but
+ *     acceptable until a virtual-scroll library is approved.
+ *
+ * @module renderer/panels/CongressPanel
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useWorldStore } from '@/store/worldStore';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
@@ -30,13 +37,13 @@ import { Hemicycle } from '../components/Hemicycle';
 import type { Legislator, Party } from '@/types';
 
 type PartyFilter = 'all' | Party;
-/**
- * Which chamber view to render.
- *   - `both` — stacked Senate over House (the legacy layout).
- *   - `senate` / `house` — focus a single chamber. Frees the rest of
- *     the panel real estate for richer charts/data, per todo#30.
- */
-type ChamberTab = 'both' | 'senate' | 'house';
+/** Single-chamber tab — no more "both". */
+type ChamberTab = 'senate' | 'house';
+
+/** Direction to sort the member list. */
+type SortKey = 'name' | 'state' | 'relationship';
+/** Whether filtered-out seats are hidden entirely or dimmed in the hemicycle. */
+type FilterMode = 'dim' | 'hide';
 
 const PARTY_LABEL: Record<Party, string> = {
   D: 'Democrat',
@@ -44,8 +51,6 @@ const PARTY_LABEL: Record<Party, string> = {
   I: 'Independent',
 };
 
-// Same palette as Hemicycle so the party-strip bars visually match
-// the seats in the chart.
 const PARTY_BAR: Record<Party, string> = {
   D: 'bg-[#5A7A8A]',
   R: 'bg-[#A85958]',
@@ -58,145 +63,210 @@ const PARTY_TEXT: Record<Party, string> = {
   I: 'text-accent-gold',
 };
 
+/** Tooltip shown at cursor when hovering a hemicycle seat. */
+interface HoverTooltip {
+  legislator: Legislator;
+  /** Client-space X (pixels from left of viewport). */
+  x: number;
+  /** Client-space Y (pixels from top of viewport). */
+  y: number;
+}
+
 export function CongressPanel(): JSX.Element {
   const senate = useWorldStore((s) => s.congress.senate);
   const house = useWorldStore((s) => s.congress.house);
 
-  const [filter, setFilter] = useState<PartyFilter>('all');
+  const [chamber, setChamber] = useState<ChamberTab>('senate');
+  const [partyFilter, setPartyFilter] = useState<PartyFilter>('all');
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('name');
+  const [filterMode, setFilterMode] = useState<FilterMode>('dim');
   const [selected, setSelected] = useState<Legislator | null>(null);
-  // Hover preview lights up the side rail without locking selection.
-  // Clicking a seat still pins via `selected` and opens the modal.
-  const [hovered, setHovered] = useState<Legislator | null>(null);
-  const [chamber, setChamber] = useState<ChamberTab>('both');
-  // Modal opens on click. We keep it separate from `selected` so the
-  // side rail can persist after the modal is dismissed (the player
-  // often wants to keep studying the same member at a glance).
   const [modalOpen, setModalOpen] = useState(false);
+  /** Floating tooltip state for seat hover. */
+  const [hoverTooltip, setHoverTooltip] = useState<HoverTooltip | null>(null);
 
-  const senateFiltered = useMemo(
-    () => (filter === 'all' ? senate : senate.filter((l) => l.party === filter)),
-    [senate, filter],
-  );
-  const houseFiltered = useMemo(
-    () => (filter === 'all' ? house : house.filter((l) => l.party === filter)),
-    [house, filter],
-  );
+  // The full list for the active chamber.
+  const chamberMembers = chamber === 'senate' ? senate : house;
+
+  // Normalised search term for case-insensitive matching.
+  const searchLower = search.toLowerCase();
 
   /**
-   * Seat-click handler: pin selection, light up rail, open modal. The
-   * three actions share a single entry point so the panel never gets
-   * into the half-state where one of them is missing.
+   * Members that match the current party filter AND search string.
+   * This is the set rendered in the right-side list.
    */
-  const onSeatClick = (l: Legislator): void => {
-    setSelected(l);
-    setHovered(l);
-    setModalOpen(true);
-  };
+  const matchedMembers = useMemo(() => {
+    return chamberMembers.filter((l) => {
+      const partyOk = partyFilter === 'all' || l.party === partyFilter;
+      if (!partyOk) return false;
+      if (!searchLower) return true;
+      // Match against name, state, personality (handy for power users).
+      return (
+        l.name.toLowerCase().includes(searchLower) ||
+        l.state.toLowerCase().includes(searchLower) ||
+        l.personality.toLowerCase().includes(searchLower)
+      );
+    });
+  }, [chamberMembers, partyFilter, searchLower]);
 
-  // The rail prefers hover (live) but falls back to the last pinned
-  // selection so the rail does not blank out on mouseleave.
-  const railSubject = hovered ?? selected;
+  /** Sorted list for the right-side roster. */
+  const sortedMembers = useMemo(() => {
+    return [...matchedMembers].sort((a, b) => {
+      switch (sortKey) {
+        case 'name': return a.name.localeCompare(b.name);
+        case 'state': return a.state.localeCompare(b.state) || a.name.localeCompare(b.name);
+        case 'relationship': return b.relationship - a.relationship;
+        default: return 0;
+      }
+    });
+  }, [matchedMembers, sortKey]);
+
+  /**
+   * Set of legislator ids to dim (or hide) in the hemicycle.
+   *
+   * When there is no active filter/search, the set is empty and all seats
+   * are fully opaque. When a filter is active, seats NOT in `matchedMembers`
+   * are either dimmed (filterMode='dim') or excluded from the legislators
+   * list passed to Hemicycle (filterMode='hide').
+   */
+  const dimmedIds = useMemo<ReadonlySet<string>>(() => {
+    const hasFilter = partyFilter !== 'all' || searchLower.length > 0;
+    if (!hasFilter) return new Set();
+    const matchedSet = new Set(matchedMembers.map((l) => l.id as unknown as string));
+    return new Set(
+      chamberMembers
+        .map((l) => l.id as unknown as string)
+        .filter((id) => !matchedSet.has(id)),
+    );
+  }, [chamberMembers, matchedMembers, partyFilter, searchLower]);
+
+  /**
+   * The legislators list passed to the Hemicycle.
+   * In 'hide' mode we exclude dimmed members entirely; in 'dim' mode we
+   * show all seats but let Hemicycle fade the non-matched ones.
+   */
+  const hemicycleMembers = useMemo(() => {
+    if (filterMode === 'hide' && dimmedIds.size > 0) {
+      return chamberMembers.filter((l) => !dimmedIds.has(l.id as unknown as string));
+    }
+    return chamberMembers;
+  }, [chamberMembers, dimmedIds, filterMode]);
+
+  /** Open the member modal. */
+  const onSeatClick = useCallback((l: Legislator): void => {
+    setSelected(l);
+    setModalOpen(true);
+    setHoverTooltip(null);
+  }, []);
+
+  /** Update the floating tooltip position and subject on hover. */
+  const onHoverPos = useCallback((l: Legislator | null, x: number, y: number): void => {
+    setHoverTooltip(l ? { legislator: l, x, y } : null);
+  }, []);
+
+  /** Total seat counts for the plinth header. */
+  const totalSeats = chamberMembers.length;
+  const majority = Math.floor(totalSeats / 2) + 1;
+
+  // Party breakdown across the full (unfiltered) chamber, so the
+  // PartyStrip always shows the real composition regardless of filter.
+  const breakdown = useMemo(
+    () => countByParty(chamberMembers),
+    [chamberMembers],
+  );
 
   return (
-    <div className="grid lg:grid-cols-[1fr_280px] gap-4 items-start">
-      <div className="space-y-4 min-w-0">
-        {/* ── CHAMBER TABS ──
-            Three-state tab strip: Both / Senate / House. Senate-only
-            and House-only views drop the second card so the focused
-            chamber owns more vertical real estate. */}
-        <div
-          className="flex items-center gap-1 border-b border-bg-tertiary"
-          role="tablist"
-          aria-label="Chamber view"
-          data-testid="congress-chamber-tabs"
-        >
-          {(
-            [
-              { id: 'both', label: 'Both Chambers' },
-              { id: 'senate', label: 'Senate' },
-              { id: 'house', label: 'House' },
-            ] as const
-          ).map((tab) => {
-            const active = chamber === tab.id;
-            return (
-              <button
-                key={tab.id}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                data-testid={`congress-tab-${tab.id}`}
-                onClick={() => setChamber(tab.id)}
-                className={[
-                  'px-3 py-2 -mb-px font-mono text-label uppercase tracking-widest transition-colors',
-                  active
-                    ? 'border-b-2 border-accent-gold text-accent-gold'
-                    : 'border-b-2 border-transparent text-text-muted hover:text-text-primary',
-                ].join(' ')}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* ── FILTER BAR ── */}
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="font-mono text-label uppercase tracking-widest text-text-muted mr-1">
-            Filter
-          </span>
-          {(['all', 'D', 'R', 'I'] as const).map((p) => (
-            <Button
-              key={p}
-              size="sm"
-              variant={filter === p ? 'primary' : 'secondary'}
-              onClick={() => setFilter(p)}
-            >
-              {p === 'all' ? 'All' : p}
-            </Button>
-          ))}
-          {selected && (
+    <div className="space-y-3">
+      {/* ── CHAMBER TABS ── */}
+      <div
+        className="flex items-center gap-1 border-b border-bg-tertiary"
+        role="tablist"
+        aria-label="Chamber"
+        data-testid="congress-chamber-tabs"
+      >
+        {([
+          { id: 'senate', label: 'Senate' },
+          { id: 'house', label: 'House' },
+        ] as const).map((tab) => {
+          const active = chamber === tab.id;
+          return (
             <button
+              key={tab.id}
               type="button"
-              onClick={() => {
-                setSelected(null);
-                setHovered(null);
-              }}
-              className="ml-auto text-label font-mono uppercase tracking-widest text-text-muted hover:text-text-primary transition-colors"
+              role="tab"
+              aria-selected={active}
+              data-testid={`congress-tab-${tab.id}`}
+              onClick={() => setChamber(tab.id)}
+              className={[
+                'px-3 py-2 -mb-px font-mono text-label uppercase tracking-widest transition-colors',
+                active
+                  ? 'border-b-2 border-accent-gold text-accent-gold'
+                  : 'border-b-2 border-transparent text-text-muted hover:text-text-primary',
+              ].join(' ')}
             >
-              Close detail
+              {tab.label}
             </button>
-          )}
+          );
+        })}
+      </div>
+
+      {/* ── MAIN LAYOUT: hemicycle left + member list right ── */}
+      <div className="grid lg:grid-cols-[1fr_320px] gap-4 items-start">
+
+        {/* ── LEFT: PLINTH + HEMICYCLE ── */}
+        <Card accent="gold" className="overflow-hidden">
+          <header className="mb-3 pb-3 border-b border-rule">
+            <div className="flex items-baseline justify-between gap-3 flex-wrap">
+              <h3 className="font-headline text-panel-title text-text-primary capitalize">
+                {chamber === 'senate' ? 'Senate' : 'House of Representatives'}
+              </h3>
+              <span className="font-mono text-data-sm text-text-muted tabular-nums">
+                {totalSeats} seats · majority {majority}
+              </span>
+            </div>
+            <PartyStrip breakdown={breakdown} total={totalSeats} className="mt-2" />
+          </header>
+          <div className="px-2 pt-1">
+            <Hemicycle
+              legislators={hemicycleMembers}
+              onSelect={onSeatClick}
+              onHoverPos={onHoverPos}
+              highlightId={selected?.id as string | undefined}
+              dimmedIds={filterMode === 'dim' ? dimmedIds : undefined}
+            />
+          </div>
+        </Card>
+
+        {/* ── RIGHT: MEMBER ROSTER ── */}
+        <div className="space-y-3 lg:sticky lg:top-0">
+          <MemberListPanel
+            members={sortedMembers}
+            total={chamberMembers.length}
+            partyFilter={partyFilter}
+            setPartyFilter={setPartyFilter}
+            search={search}
+            setSearch={setSearch}
+            sortKey={sortKey}
+            setSortKey={setSortKey}
+            filterMode={filterMode}
+            setFilterMode={setFilterMode}
+            onSelect={onSeatClick}
+            selected={selected}
+          />
         </div>
-
-        {(chamber === 'both' || chamber === 'senate') && (
-          <ChamberCard
-            title="Senate"
-            legislators={senateFiltered}
-            totalSeats={senate.length}
-            majority={Math.floor(senate.length / 2) + 1}
-            onSelect={onSeatClick}
-            onHover={setHovered}
-            highlightId={selected?.id as string | undefined}
-          />
-        )}
-        {(chamber === 'both' || chamber === 'house') && (
-          <ChamberCard
-            title="House of Representatives"
-            legislators={houseFiltered}
-            totalSeats={house.length}
-            majority={Math.floor(house.length / 2) + 1}
-            onSelect={onSeatClick}
-            onHover={setHovered}
-            highlightId={selected?.id as string | undefined}
-          />
-        )}
       </div>
 
-      {/* ── DETAIL RAIL ── */}
-      <div className="lg:sticky lg:top-0">
-        <LegislatorDetail legislator={railSubject} />
-      </div>
+      {/* ── CURSOR TOOLTIP ── */}
+      {hoverTooltip && (
+        <SeatTooltip
+          legislator={hoverTooltip.legislator}
+          x={hoverTooltip.x}
+          y={hoverTooltip.y}
+        />
+      )}
 
+      {/* ── MEMBER MODAL ── */}
       {modalOpen && selected && (
         <MemberModal
           legislator={selected}
@@ -208,49 +278,215 @@ export function CongressPanel(): JSX.Element {
 }
 
 // ─────────────────────────────────────────────────────────────
-// CHAMBER CARD
-// Plinth header + hemicycle for a single chamber.
+// SEAT TOOLTIP
+// Fixed-position card that follows the cursor. Shown on seat hover;
+// dismissed on mouseleave via the parent state reset.
 // ─────────────────────────────────────────────────────────────
 
-function ChamberCard({
-  title,
-  legislators,
-  totalSeats,
-  majority,
-  onSelect,
-  onHover,
-  highlightId,
+/**
+ * Lightweight floating card shown when the player hovers a hemicycle
+ * seat. Positioned at `(x, y)` in client space with a small offset so
+ * the cursor doesn't cover the text. The tooltip is `pointer-events-none`
+ * so it doesn't swallow the SVG mouse events underneath it.
+ *
+ * @param legislator — member to summarise.
+ * @param x — clientX from the SVG circle's onMouseEnter.
+ * @param y — clientY from the SVG circle's onMouseEnter.
+ */
+function SeatTooltip({
+  legislator: l,
+  x,
+  y,
 }: {
-  title: string;
-  legislators: readonly Legislator[];
-  totalSeats: number;
-  majority: number;
-  onSelect: (l: Legislator) => void;
-  onHover?: (l: Legislator | null) => void;
-  highlightId?: string;
+  legislator: Legislator;
+  x: number;
+  y: number;
 }): JSX.Element {
-  const breakdown = useMemo(() => countByParty(legislators), [legislators]);
+  const r = l.relationship;
+  const relCls =
+    r < -25 ? 'text-status-danger' :
+    r < 25  ? 'text-status-warning' :
+    'text-accent-gold';
+
+  const votes = Object.entries(l.votingHistory);
+  const yeas = votes.filter(([, v]) => v === 'yea').length;
+  const nays = votes.filter(([, v]) => v === 'nay').length;
 
   return (
-    <Card accent="gold" className="overflow-hidden">
-      <header className="mb-3 pb-3 border-b border-rule">
-        <div className="flex items-baseline justify-between gap-3 flex-wrap">
-          <h3 className="font-headline text-panel-title text-text-primary">{title}</h3>
-          <span className="font-mono text-data-sm text-text-muted tabular-nums">
-            {legislators.length} of {totalSeats} · majority {majority}
+    <div
+      className="fixed z-50 pointer-events-none bg-bg-secondary border border-bg-tertiary rounded-md shadow-xl px-3 py-2 min-w-[180px]"
+      style={{
+        left: Math.min(x + 12, window.innerWidth - 200),
+        top: Math.max(y - 60, 8),
+      }}
+      data-testid="congress-seat-tooltip"
+    >
+      <p className="font-headline text-sm font-bold text-text-primary">{l.name}</p>
+      <p className={`font-mono text-[0.6875rem] uppercase tracking-widest ${PARTY_TEXT[l.party]}`}>
+        {l.party}-{l.state}
+        {l.district !== undefined ? `-${l.district}` : ''}&nbsp;·&nbsp;{l.chamber.toUpperCase()}
+      </p>
+      <div className="mt-1 flex items-baseline justify-between text-[0.75rem]">
+        <span className="text-text-muted font-mono">Rel.</span>
+        <span className={`font-mono font-bold tabular-nums ${relCls}`}>
+          {r > 0 ? '+' : ''}{r}
+        </span>
+      </div>
+      {votes.length > 0 && (
+        <div className="mt-0.5 flex items-baseline justify-between text-[0.75rem]">
+          <span className="text-text-muted font-mono">Votes</span>
+          <span className="font-mono tabular-nums text-text-secondary">
+            <span className="text-status-success">{yeas}Y</span>
+            {' / '}
+            <span className="text-status-danger">{nays}N</span>
           </span>
         </div>
-        <PartyStrip breakdown={breakdown} total={legislators.length} className="mt-2" />
-      </header>
+      )}
+    </div>
+  );
+}
 
-      <div className="px-2 pt-1">
-        <Hemicycle
-          legislators={legislators}
-          onSelect={onSelect}
-          onHover={onHover}
-          highlightId={highlightId}
+// ─────────────────────────────────────────────────────────────
+// MEMBER LIST PANEL
+// Scrollable roster with search, party filter, sort, and hide/dim toggle.
+// ─────────────────────────────────────────────────────────────
+
+function MemberListPanel({
+  members,
+  total,
+  partyFilter,
+  setPartyFilter,
+  search,
+  setSearch,
+  sortKey,
+  setSortKey,
+  filterMode,
+  setFilterMode,
+  onSelect,
+  selected,
+}: {
+  members: readonly Legislator[];
+  total: number;
+  partyFilter: PartyFilter;
+  setPartyFilter: (p: PartyFilter) => void;
+  search: string;
+  setSearch: (s: string) => void;
+  sortKey: SortKey;
+  setSortKey: (k: SortKey) => void;
+  filterMode: FilterMode;
+  setFilterMode: (m: FilterMode) => void;
+  onSelect: (l: Legislator) => void;
+  selected: Legislator | null;
+}): JSX.Element {
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <Card title="Members" subtitle={`${members.length} of ${total}`}>
+      {/* ── SEARCH ── */}
+      <div className="relative mb-2">
+        <Icon
+          name="search"
+          size={14}
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted"
+        />
+        <input
+          ref={searchRef}
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Name, state, or personality…"
+          className="w-full bg-bg-tertiary border border-rule rounded-sm pl-8 pr-3 py-1.5 font-mono text-[0.8125rem] text-text-primary placeholder-text-muted focus:outline-none focus:ring-1 focus:ring-accent-gold/40"
+          data-testid="congress-member-search"
+          aria-label="Search members"
         />
       </div>
+
+      {/* ── PARTY FILTER ── */}
+      <div className="flex items-center gap-1 mb-2 flex-wrap">
+        {(['all', 'D', 'R', 'I'] as const).map((p) => (
+          <Button
+            key={p}
+            size="sm"
+            variant={partyFilter === p ? 'primary' : 'secondary'}
+            onClick={() => setPartyFilter(p)}
+            data-testid={`congress-filter-${p}`}
+          >
+            {p === 'all' ? 'All' : p}
+          </Button>
+        ))}
+        {/* Hide / Dim toggle */}
+        <button
+          type="button"
+          onClick={() => setFilterMode(filterMode === 'dim' ? 'hide' : 'dim')}
+          className="ml-auto flex items-center gap-1 font-mono text-label uppercase tracking-widest text-text-muted hover:text-text-primary transition-colors"
+          title={filterMode === 'dim' ? 'Dim filtered seats (click to hide instead)' : 'Hide filtered seats (click to dim instead)'}
+          data-testid="congress-filter-mode-toggle"
+        >
+          <Icon name={filterMode === 'dim' ? 'eye' : 'eye-off'} size={13} />
+          {filterMode === 'dim' ? 'Dim' : 'Hide'}
+        </button>
+      </div>
+
+      {/* ── SORT ── */}
+      <div className="flex items-center gap-1 mb-3">
+        <span className="font-mono text-label uppercase tracking-widest text-text-muted mr-1">
+          Sort
+        </span>
+        {(['name', 'state', 'relationship'] as const).map((key) => (
+          <Button
+            key={key}
+            size="sm"
+            variant={sortKey === key ? 'primary' : 'secondary'}
+            onClick={() => setSortKey(key)}
+            data-testid={`congress-sort-${key}`}
+          >
+            {key === 'relationship' ? 'Rel.' : key.charAt(0).toUpperCase() + key.slice(1)}
+          </Button>
+        ))}
+      </div>
+
+      {/* ── ROSTER ── */}
+      {members.length === 0 ? (
+        <p className="text-body text-text-muted italic">No members match the current filter.</p>
+      ) : (
+        <ul
+          className="space-y-0.5 max-h-[60vh] overflow-y-auto game-scroll pr-1"
+          data-testid="congress-member-list"
+        >
+          {members.map((l) => {
+            const r = l.relationship;
+            const relCls =
+              r < -25 ? 'text-status-danger' :
+              r < 25  ? 'text-status-warning' :
+              'text-accent-gold';
+            const isSelected = selected?.id === l.id;
+            return (
+              <li key={l.id as unknown as string}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(l)}
+                  className={[
+                    'w-full flex items-center gap-2 px-2 py-1 rounded-sm text-left text-[0.8125rem] transition-colors',
+                    isSelected
+                      ? 'bg-accent-gold/10 border border-accent-gold/30'
+                      : 'hover:bg-bg-tertiary/60 border border-transparent',
+                  ].join(' ')}
+                  data-testid="congress-member-row"
+                >
+                  <span className={`font-mono text-[0.6875rem] uppercase w-4 shrink-0 ${PARTY_TEXT[l.party]}`}>
+                    {l.party}
+                  </span>
+                  <span className="flex-1 truncate text-text-primary">{l.name}</span>
+                  <span className="font-mono text-[0.6875rem] text-text-muted shrink-0">{l.state}</span>
+                  <span className={`font-mono text-[0.6875rem] tabular-nums shrink-0 ${relCls}`}>
+                    {r > 0 ? '+' : ''}{r}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </Card>
   );
 }
@@ -305,92 +541,9 @@ function countByParty(legislators: readonly Legislator[]): Record<Party, number>
 }
 
 // ─────────────────────────────────────────────────────────────
-// LEGISLATOR DETAIL RAIL
-// Shown when a seat is clicked. Empty-state teaches the interaction.
+// DETAIL UTILITIES  (DetailRow, VoteBadge)
+// Shared between SeatTooltip, MemberListPanel, and MemberModal.
 // ─────────────────────────────────────────────────────────────
-
-function LegislatorDetail({ legislator }: { legislator: Legislator | null }): JSX.Element {
-  if (!legislator) {
-    return (
-      <Card title="Member" subtitle="DETAIL">
-        <p className="text-body text-text-muted italic">
-          Click a seat to inspect a legislator — their ideology,
-          relationship with you, and voting record.
-        </p>
-      </Card>
-    );
-  }
-
-  const r = legislator.relationship;
-  const relTone: 'danger' | 'warning' | 'gold' =
-    r < -25 ? 'danger' : r < 25 ? 'warning' : 'gold';
-  const votes = Object.entries(legislator.votingHistory);
-
-  return (
-    <Card
-      title={legislator.name}
-      subtitle={`${legislator.party}-${legislator.state}${
-        legislator.district !== undefined ? `-${legislator.district}` : ''
-      } · ${legislator.chamber.toUpperCase()}`}
-    >
-      <div className="space-y-3">
-        <DetailRow label="Relationship" value={`${r > 0 ? '+' : ''}${r}`} tone={relTone} />
-        <DetailRow label="Personality" value={legislator.personality} />
-        <DetailRow
-          label="Ideology"
-          value={`${legislator.ideology.x.toFixed(2)} · ${legislator.ideology.y.toFixed(2)}`}
-        />
-        <DetailRow label="Term ends" value={String(legislator.termEndsYear)} />
-
-        <div>
-          <div className="font-mono text-label uppercase tracking-widest text-text-muted mb-1">
-            Priorities
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {legislator.priorities.length === 0 ? (
-              <span className="text-body text-text-muted italic">None recorded</span>
-            ) : (
-              legislator.priorities.map((p) => (
-                <span
-                  key={p}
-                  className="font-mono text-[0.6875rem] uppercase tracking-wider px-1.5 py-0.5 bg-bg-tertiary text-text-secondary rounded-sm"
-                >
-                  {p}
-                </span>
-              ))
-            )}
-          </div>
-        </div>
-
-        <div>
-          <div className="flex items-center justify-between mb-1">
-            <span className="font-mono text-label uppercase tracking-widest text-text-muted">
-              Voting record
-            </span>
-            <span className="font-mono text-data-sm text-text-muted tabular-nums">
-              {votes.length}
-            </span>
-          </div>
-          {votes.length === 0 ? (
-            <p className="text-body text-text-muted italic">No votes cast yet.</p>
-          ) : (
-            <ul className="space-y-1 max-h-48 overflow-y-auto game-scroll pr-1">
-              {votes.slice(-10).reverse().map(([billId, vote]) => (
-                <li
-                  key={billId}
-                  className="flex justify-between items-center text-[0.8125rem]"
-                >
-                  <span className="text-text-secondary truncate mr-2">{billId}</span>
-                  <VoteBadge vote={vote} />
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-    </Card>
-  );
-}
 
 function DetailRow({
   label,
@@ -439,19 +592,12 @@ function VoteBadge({ vote }: { vote: 'yea' | 'nay' | 'abstain' }): JSX.Element {
 
 // ─────────────────────────────────────────────────────────────
 // MEMBER MODAL
-// Click-to-open detail surface. The side rail stays as the live
-// hover preview; this modal is where the player goes to *study* a
-// member. Same data as the rail today, with extra room for an
-// ideology compass and a research-mechanic placeholder (todo#30
-// follow-up tracked as an issue).
+// Full detail surface opened on seat click or member row click.
 // ─────────────────────────────────────────────────────────────
 
 /**
- * Lay out the four-panel modal. Closes on Escape and on backdrop
- * click. We do not use ModalShell because the two competing
- * confirmation patterns (ModalShell's stack + this panel-level state)
- * fight over Escape; a self-contained modal keeps focus management
- * simple while we iterate on the panel.
+ * Deep-dive modal for a single legislator. Shows stat block + voting
+ * record summary + recent votes. Closes on Escape or backdrop click.
  */
 function MemberModal({
   legislator,
@@ -460,8 +606,6 @@ function MemberModal({
   legislator: Legislator;
   onClose: () => void;
 }): JSX.Element {
-  // Escape-to-close. Effect lives on the modal itself so unmounting
-  // tears the listener down cleanly.
   useEffect(() => {
     function onKey(e: KeyboardEvent): void {
       if (e.key === 'Escape') onClose();
@@ -508,7 +652,7 @@ function MemberModal({
         </header>
 
         <div className="px-5 py-4 grid md:grid-cols-2 gap-5 overflow-y-auto game-scroll">
-          {/* Left column: stat block. */}
+          {/* Left: stat block */}
           <section className="space-y-3" data-testid="member-modal-stats">
             <DetailRow
               label="Relationship"
@@ -558,7 +702,7 @@ function MemberModal({
             </div>
           </section>
 
-          {/* Right column: voting record summary + recent votes. */}
+          {/* Right: voting record */}
           <section className="space-y-3" data-testid="member-modal-votes">
             <div>
               <div className="font-mono text-label uppercase tracking-widest text-text-muted mb-2">
@@ -630,3 +774,4 @@ function VoteTotal({
     </div>
   );
 }
+

--- a/src/renderer/screens/Game.tsx
+++ b/src/renderer/screens/Game.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useUIStore } from '@/store/uiStore';
+import type { VoteResultPayload } from '@/store/uiStore';
 import { useWorldStore } from '@/store/worldStore';
 import { useGameStore } from '@/store/gameStore';
 import { TimeEngine } from '@/engine/TimeEngine';
@@ -10,6 +11,7 @@ import { Sidebar } from '../components/Sidebar';
 import { BottomBar } from '../components/BottomBar';
 import { ModalShell } from '../components/ModalShell';
 import { Button } from '../components/Button';
+import { Icon } from '../components/Icon';
 
 import { DashboardPanel } from '../panels/DashboardPanel';
 import { LegislationPanel } from '../panels/LegislationPanel';
@@ -144,6 +146,7 @@ export function Game(): JSX.Element {
       </div>
       <BottomBar />
       {activeEvents.length > 0 && <EventModal />}
+      <VoteResultModal />
     </div>
   );
 }
@@ -184,5 +187,171 @@ function EventModal(): JSX.Element | null {
         ))}
       </div>
     </ModalShell>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// VOTE RESULT MODAL (todo#85)
+// Rendered whenever uiStore has a 'vote-result' modal queued. Shows
+// a styled breakdown of the roll-call: PASSED/FAILED banner, yea/nay
+// totals, and a scrollable per-senator list the player can review
+// before dismissing. Game time is paused (the engine is ticking but
+// the modal gives context); the player can always dismiss and return
+// to the Legislation panel for further review.
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Reads the first 'vote-result' modal from uiStore, if any, and renders
+ * a full-screen overlay with the roll-call details. Nothing renders when
+ * the queue is empty.
+ */
+function VoteResultModal(): JSX.Element | null {
+  const modals = useUIStore((s) => s.modals);
+  const closeModal = useUIStore((s) => s.closeModal);
+
+  // Pick the first vote-result in the queue; other modal types are
+  // handled by their own components (e.g. EventModal above).
+  const modal = modals.find((m) => m.type === 'vote-result');
+  if (!modal) return null;
+
+  const data = modal.payload as VoteResultPayload;
+  const { billTitle, passed, yea, nay, breakdown } = data;
+  const total = yea + nay;
+
+  // Sort: yeas first, then nays, each group alpha by last name so the
+  // player can scan for specific members quickly.
+  const sorted = [...breakdown].sort((a, b) => {
+    if (a.vote !== b.vote) return a.vote === 'yea' ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const PARTY_TEXT: Record<'D' | 'R' | 'I', string> = {
+    D: 'text-[#7B9BAB]',
+    R: 'text-[#C07A79]',
+    I: 'text-accent-gold',
+  };
+
+  function dismiss(): void {
+    closeModal(modal.id);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Vote result for ${billTitle}`}
+      onClick={dismiss}
+      data-testid="vote-result-modal"
+    >
+      <div
+        className="w-full max-w-2xl bg-bg-secondary rounded-lg border border-bg-tertiary shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ── HEADER ── */}
+        <header
+          className={[
+            'px-6 py-5 border-b border-bg-tertiary flex flex-col gap-1',
+            passed ? 'bg-status-success/10' : 'bg-status-danger/10',
+          ].join(' ')}
+        >
+          {/* PASSED / FAILED banner */}
+          <div
+            className={[
+              'font-headline text-3xl font-bold tracking-widest uppercase',
+              passed ? 'text-status-success' : 'text-status-danger',
+            ].join(' ')}
+            data-testid="vote-result-verdict"
+          >
+            {passed ? 'Passed' : 'Failed'}
+          </div>
+          <p className="font-mono text-label text-text-muted uppercase tracking-widest">
+            {billTitle}
+          </p>
+        </header>
+
+        {/* ── VOTE TOTALS ── */}
+        <div
+          className="grid grid-cols-2 divide-x divide-bg-tertiary border-b border-bg-tertiary"
+          data-testid="vote-result-totals"
+        >
+          {/* YEA */}
+          <div className="flex flex-col items-center py-4 gap-1">
+            <span
+              className="font-mono text-4xl font-bold text-status-success tabular-nums"
+              data-testid="vote-result-yea"
+            >
+              {yea}
+            </span>
+            <div className="flex items-center gap-1 font-mono text-label uppercase tracking-widest text-text-muted">
+              <Icon name="check" size={12} />
+              Yea
+            </div>
+            {/* Proportion bar */}
+            <div className="w-24 h-1.5 rounded-full bg-bg-tertiary overflow-hidden">
+              <div
+                className="h-full bg-status-success rounded-full"
+                style={{ width: total > 0 ? `${(yea / total) * 100}%` : '0%' }}
+              />
+            </div>
+          </div>
+
+          {/* NAY */}
+          <div className="flex flex-col items-center py-4 gap-1">
+            <span
+              className="font-mono text-4xl font-bold text-status-danger tabular-nums"
+              data-testid="vote-result-nay"
+            >
+              {nay}
+            </span>
+            <div className="flex items-center gap-1 font-mono text-label uppercase tracking-widest text-text-muted">
+              <Icon name="close" size={12} />
+              Nay
+            </div>
+            {/* Proportion bar */}
+            <div className="w-24 h-1.5 rounded-full bg-bg-tertiary overflow-hidden">
+              <div
+                className="h-full bg-status-danger rounded-full"
+                style={{ width: total > 0 ? `${(nay / total) * 100}%` : '0%' }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* ── SENATOR BREAKDOWN ── */}
+        {breakdown.length > 0 && (
+          <div className="flex-1 overflow-y-auto game-scroll px-4 py-3">
+            <p className="font-mono text-label uppercase tracking-widest text-text-muted mb-2">
+              Roll-call ({total} senators)
+            </p>
+            <ul className="grid grid-cols-1 sm:grid-cols-2 gap-0.5">
+              {sorted.map((rec) => (
+                <li
+                  key={rec.id}
+                  className="flex justify-between items-center px-2 py-1 rounded-sm text-[0.8125rem] even:bg-bg-tertiary/20"
+                >
+                  <span className={`font-mono text-[0.6875rem] uppercase mr-2 ${PARTY_TEXT[rec.party]}`}>
+                    {rec.party}
+                  </span>
+                  <span className="flex-1 text-text-secondary truncate">{rec.name}</span>
+                  <span className="font-mono text-label ml-2">
+                    <span className={rec.vote === 'yea' ? 'text-status-success' : 'text-status-danger'}>
+                      {rec.vote === 'yea' ? 'Yea' : 'Nay'}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* ── FOOTER ── */}
+        <footer className="px-6 py-3 border-t border-bg-tertiary flex justify-end">
+          <Button variant="primary" onClick={dismiss} data-testid="vote-result-dismiss">
+            Dismiss
+          </Button>
+        </footer>
+      </div>
+    </div>
   );
 }

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -16,9 +16,19 @@ export type PanelId =
   | 'timeline'
   | 'patch-notes';
 
+/** Payload attached to a 'vote-result' modal (todo#85). */
+export interface VoteResultPayload {
+  billTitle: string;
+  passed: boolean;
+  yea: number;
+  nay: number;
+  /** Individual senator votes, sorted yeas-first then nays. */
+  breakdown: Array<{ id: string; name: string; party: 'D' | 'R' | 'I'; state: string; vote: 'yea' | 'nay' }>;
+}
+
 export interface ModalState {
   id: string;
-  type: 'event' | 'bill' | 'dialogue' | 'confirm' | 'info';
+  type: 'event' | 'bill' | 'dialogue' | 'confirm' | 'info' | 'vote-result';
   payload?: unknown;
 }
 

--- a/src/systems/LegislationSystem.ts
+++ b/src/systems/LegislationSystem.ts
@@ -72,11 +72,22 @@ export interface ExpediteResult {
   reason?: string;
 }
 
-/** Result shape returned by `resolveVote`. Unchanged from pre-pacing. */
+/** A single legislator's recorded vote, returned with the `VoteResult`. */
+export interface LegislatorVoteRecord {
+  id: string;
+  name: string;
+  party: 'D' | 'R' | 'I';
+  state: string;
+  vote: 'yea' | 'nay';
+}
+
+/** Result shape returned by `resolveVote`. */
 export interface VoteResult {
   passed: boolean;
   yea: number;
   nay: number;
+  /** Per-legislator breakdown, populated after #83 fix. */
+  breakdown: LegislatorVoteRecord[];
 }
 
 export interface LegislationSystemAPI {
@@ -239,6 +250,19 @@ class LegislationSystemImpl implements LegislationSystemAPI {
     // Resolve the vote instead of transitioning to a new waiting stage.
     if (bill.stage === 'vote') {
       const result = this.resolveVote(billId);
+      // Show the styled vote-result modal so the player gets the same
+      // breakdown whether the vote was expedited or auto-resolved.
+      useUIStore.getState().openModal({
+        id: `vote-result-${billId}`,
+        type: 'vote-result',
+        payload: {
+          billTitle: bill.title,
+          passed: result.passed,
+          yea: result.yea,
+          nay: result.nay,
+          breakdown: result.breakdown,
+        },
+      });
       return {
         ok: true,
         newStage: result.passed ? 'signed' : 'failed',
@@ -266,7 +290,7 @@ class LegislationSystemImpl implements LegislationSystemAPI {
   resolveVote(billId: BillId): VoteResult {
     const world = useWorldStore.getState();
     const bill = world.pendingLegislation.find((b) => b.id === billId);
-    if (!bill) return { passed: false, yea: 0, nay: 0 };
+    if (!bill) return { passed: false, yea: 0, nay: 0, breakdown: [] };
 
     const strategy = useCharacterStore.getState().stats.strategy;
     const rng = new SeededRNG(world.seed + Number(billId.replace(/\D/g, '') || 0));
@@ -274,6 +298,12 @@ class LegislationSystemImpl implements LegislationSystemAPI {
 
     let yea = 0;
     let nay = 0;
+    // Collect each senator's individual vote so we can:
+    //  (a) write it back to their `votingHistory` (fixes todo#83 —
+    //      the rail/modal now has real data to display), and
+    //  (b) pass the full breakdown to the vote-result modal (todo#85).
+    const breakdown: LegislatorVoteRecord[] = [];
+
     for (const legis of senate) {
       const p = perLegislatorPassChance({
         alignment: legis.priorities.some((pri) => bill.tags.includes(pri)),
@@ -281,8 +311,25 @@ class LegislationSystemImpl implements LegislationSystemAPI {
         opposition: bill.opposition,
         strategy,
       });
-      if (rng.next() < p) yea++;
+      const voted: 'yea' | 'nay' = rng.next() < p ? 'yea' : 'nay';
+      if (voted === 'yea') yea++;
       else nay++;
+
+      breakdown.push({
+        id: legis.id as unknown as string,
+        name: legis.name,
+        party: legis.party,
+        state: legis.state,
+        vote: voted,
+      });
+
+      // Merge the new vote entry into the senator's history. We spread
+      // the existing record to avoid clobbering prior votes — the store
+      // action uses Object.assign which would replace the entire object
+      // if we only sent the new key.
+      world.updateLegislator(legis.id as unknown as string, {
+        votingHistory: { ...legis.votingHistory, [billId]: voted },
+      });
     }
 
     const passed = yea >= 51;
@@ -297,7 +344,7 @@ class LegislationSystemImpl implements LegislationSystemAPI {
     } else {
       world.movePending(billId, 'failed');
     }
-    return { passed, yea, nay };
+    return { passed, yea, nay, breakdown };
   }
 
   // ─────────────────────────────────────────────────────────────
@@ -332,10 +379,24 @@ class LegislationSystemImpl implements LegislationSystemAPI {
       // advance; time is the toll.
       if (bill.stage === 'vote') {
         const result = this.resolveVote(bill.id);
+        // Push the styled vote-result modal (todo#85). The brief toast is
+        // still kept so the player sees a notification if they dismiss the
+        // modal instantly or if the modal fires off-screen.
+        useUIStore.getState().openModal({
+          id: `vote-result-${bill.id}`,
+          type: 'vote-result',
+          payload: {
+            billTitle: bill.title,
+            passed: result.passed,
+            yea: result.yea,
+            nay: result.nay,
+            breakdown: result.breakdown,
+          },
+        });
         pushToast({
           message: result.passed
-            ? `${bill.title} PASSED ${result.yea}–${result.nay}`
-            : `${bill.title} FAILED ${result.yea}–${result.nay}`,
+            ? `${bill.title} PASSED ${result.yea}\u2013${result.nay}`
+            : `${bill.title} FAILED ${result.yea}\u2013${result.nay}`,
           severity: result.passed ? 'success' : 'danger',
           ttl: 5000,
         });


### PR DESCRIPTION
## Summary
Addresses todo#69, todo#83, and todo#85.

## Changes

### CongressPanel (todo#69)
- Eliminated the stacked both-chambers layout. Players select Senate or House via a two-tab strip.
- Left column: plinth header (seats, majority, party bar) + hemicycle SVG.
- Right column: MemberListPanel with real-time search, party filter, sort (name/state/relationship), and dim-vs-hide toggle that controls hemicycle seat opacity.
- Hovering a seat shows a floating SeatTooltip anchored at the cursor (pointer-events-none, no layout reflow).
- Clicking a seat or member row opens MemberModal with stat block + voting-record summary + recent votes.

### Hemicycle (todo#69)
- Replaced `onHover` with `onHoverPos` (passes clientX/Y so the parent anchors the tooltip without DOM queries).
- Added `dimmedIds` prop — seats in the set fade to opacity 0.18 with a 150ms transition, preserving spatial context while highlighting matched members.

### Vote counts fix (todo#83)
- `LegislationSystem.resolveVote` now calls `world.updateLegislator` per senator, writing `yea | nay` into `votingHistory`.
- `MemberModal` shows live Yea/Nay/Abstain tiles and a recent-votes scroll list (up to 25).

### Vote result modal (todo#85)
- `resolveVote` (daily-tick and expediteStage paths) pushes a `vote-result` modal via `uiStore.openModal` alongside the existing toast.
- `VoteResultModal` in `Game.tsx`: PASSED/FAILED verdict banner, yea/nay totals with relative-width bars, scrollable per-senator roll-call sorted yeas-first.

### Icons
- Added `eye` and `eye-off` Tabler icons to `Icon.tsx` for the dim/hide toggle.

## Testing
- `npx tsc --noEmit` — clean (exit 0)
- `npm run lint` — 0 errors, 0 warnings
- `npx vitest run` — 236/236 passed

## Docs
UI redesign within existing GDD spec; no doc section changes required. Changelog entry will be added in the next bundle.

Closes #69
Refs todo#83, todo#85
