### PR TITLE
feat(electron): hide menu bar, persist fullscreen, autosave every 4 weeks

### DIFF
--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -30,6 +30,7 @@ import { LegislationSystem } from '@/systems/LegislationSystem';
 
 import { hashString, SeededRNG } from '@/utils/random';
 import { createLogger } from '@/utils/logger';
+import { writeSave } from './SaveSystem';
 
 const log = createLogger('GameEngine');
 
@@ -82,6 +83,18 @@ class GameEngineImpl implements GameEngineAPI {
   };
 
   private unsubs: Array<() => void> = [];
+
+  /**
+   * Counts game weeks elapsed since the last autosave. When this reaches
+   * AUTOSAVE_INTERVAL (4 weeks ≈ 1 in-game month) a silent save is written
+   * to the reserved 'autosave' slot. The counter resets after each save.
+   *
+   * 4 weeks was chosen as a balance between "save frequently enough that
+   * a crash is not catastrophic" and "don't hammer the disk or interrupt
+   * the player with autosave lag on slow machines". (#78)
+   */
+  private autosaveWeekCounter = 0;
+  private static readonly AUTOSAVE_INTERVAL = 4;
 
   registerData(bundle: DataBundle): void {
     this.bundle = bundle;
@@ -203,6 +216,22 @@ class GameEngineImpl implements GameEngineAPI {
         ActionEngine.weeklyRegenerate();
         AchievementEngine.check();
         CardSystem.drawToHandSize(5);
+
+        // ── AUTOSAVE (#78) ──────────────────────────────────────────
+        // Increment the counter and trigger a silent save every
+        // AUTOSAVE_INTERVAL weeks. writeSave is async (IPC round-trip
+        // in Electron, localStorage in browser); we fire-and-forget
+        // so the tick never blocks on I/O. The reserved slot name
+        // 'autosave' is never presented to the player as a named slot —
+        // it is overwritten on every interval.
+        this.autosaveWeekCounter += 1;
+        if (this.autosaveWeekCounter >= GameEngineImpl.AUTOSAVE_INTERVAL) {
+          this.autosaveWeekCounter = 0;
+          void writeSave('autosave', 'Autosave').then((ok) => {
+            if (ok) log.info('autosave written');
+            else log.warn('autosave failed');
+          });
+        }
       }),
       TimeEngine.onMonthly(() => {
         EconomySystem.monthlyReport();
@@ -234,6 +263,8 @@ class GameEngineImpl implements GameEngineAPI {
     TimeEngine.stop();
     for (const unsub of this.unsubs) unsub();
     this.unsubs = [];
+    // Reset autosave counter so a new game starts fresh. (#78)
+    this.autosaveWeekCounter = 0;
   }
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -38,6 +38,10 @@ const persist = new Store<StoreSchema>({
 });
 
 function createMainWindow(): BrowserWindow {
+  // Read persisted settings so we can restore display prefs on launch.
+  const savedSettings = persist.get('settings') as Record<string, unknown>;
+  const restoreFullscreen = savedSettings.fullscreen === true;
+
   const win = new BrowserWindow({
     width: 1440,
     height: 900,
@@ -45,7 +49,11 @@ function createMainWindow(): BrowserWindow {
     minHeight: 700,
     backgroundColor: '#0F1117',
     show: false,
-    autoHideMenuBar: false,
+    // Menu bar is hidden by default (reappears on Alt/F10 on Windows).
+    // This keeps the game surface clean without permanently removing the
+    // menu — the View → Toggle Fullscreen and Help items remain
+    // discoverable for players who need them. (#79)
+    autoHideMenuBar: true,
     title: 'Political Ascent',
     webPreferences: {
       preload: join(__dirname, 'preload.js'),
@@ -56,7 +64,26 @@ function createMainWindow(): BrowserWindow {
     },
   });
 
-  win.once('ready-to-show', () => win.show());
+  win.once('ready-to-show', () => {
+    win.show();
+    // Restore fullscreen state from the last session. We set it here
+    // (inside ready-to-show) so the window is already visible before
+    // it enters full screen, which avoids a black-flash on some GPUs.
+    // (#80)
+    if (restoreFullscreen) win.setFullScreen(true);
+  });
+
+  // Persist the current fullscreen state whenever the window
+  // enters or leaves full screen (keyboard shortcut, menu item, or
+  // a programmatic call from the renderer). (#80)
+  win.on('enter-full-screen', () => {
+    const s = persist.get('settings') as Record<string, unknown>;
+    persist.set('settings', { ...s, fullscreen: true });
+  });
+  win.on('leave-full-screen', () => {
+    const s = persist.get('settings') as Record<string, unknown>;
+    persist.set('settings', { ...s, fullscreen: false });
+  });
 
   win.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
@@ -148,6 +175,25 @@ function registerIpc(): void {
 
   ipcMain.handle('pa:app:version', () => app.getVersion());
   ipcMain.handle('pa:app:platform', () => process.platform);
+
+  // Fullscreen toggle — called from the Settings screen. The window
+  // 'enter-full-screen' / 'leave-full-screen' events then persist the
+  // new state automatically. (#80)
+  ipcMain.handle('pa:window:setFullscreen', (_event, value: boolean) => {
+    const [win] = BrowserWindow.getAllWindows();
+    if (win) {
+      win.setFullScreen(value);
+      return true;
+    }
+    return false;
+  });
+
+  // Report current fullscreen state to the renderer so the Settings
+  // screen can initialise its toggle to the correct value.
+  ipcMain.handle('pa:window:isFullscreen', () => {
+    const [win] = BrowserWindow.getAllWindows();
+    return win ? win.isFullScreen() : false;
+  });
 }
 
 void app.whenReady().then(() => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -26,6 +26,18 @@ export interface PoliticalAscentBridge {
     get: () => Promise<Record<string, unknown>>;
     set: (settings: Record<string, unknown>) => Promise<boolean>;
   };
+  window: {
+    /**
+     * Set the window fullscreen state and persist it so it is
+     * restored on the next launch. (#80)
+     */
+    setFullscreen: (value: boolean) => Promise<boolean>;
+    /**
+     * Returns the current fullscreen state of the BrowserWindow.
+     * Used by Settings to initialise its toggle. (#80)
+     */
+    isFullscreen: () => Promise<boolean>;
+  };
 }
 
 const api: PoliticalAscentBridge = {
@@ -40,6 +52,10 @@ const api: PoliticalAscentBridge = {
   settings: {
     get: () => ipcRenderer.invoke('pa:settings:get'),
     set: (settings) => ipcRenderer.invoke('pa:settings:set', settings),
+  },
+  window: {
+    setFullscreen: (value) => ipcRenderer.invoke('pa:window:setFullscreen', value),
+    isFullscreen: () => ipcRenderer.invoke('pa:window:isFullscreen'),
   },
 };
 

--- a/src/renderer/screens/Settings.tsx
+++ b/src/renderer/screens/Settings.tsx
@@ -46,6 +46,10 @@ export function Settings(): JSX.Element {
             onChange={(v) => updateDisplay({ fontScale: v / 100 })}
           />
           <Toggle label="Reduce motion" value={settings.display.reduceMotion} onChange={(v) => updateDisplay({ reduceMotion: v })} />
+          {/* Fullscreen toggle: delegates to Electron BrowserWindow so
+              the preference is persisted and restored on next launch.
+              No-ops in the browser / mobile builds. (#80) */}
+          <FullscreenToggle />
         </Card>
         <Card title="Accessibility">
           <Toggle label="High contrast" value={settings.accessibility.highContrast} onChange={(v) => updateAccessibility({ highContrast: v })} />
@@ -195,5 +199,43 @@ function DeveloperCard(): JSX.Element {
         </div>
       )}
     </Card>
+  );
+}
+
+/**
+ * Fullscreen toggle for the Display section of Settings.
+ *
+ * Reads the current window fullscreen state via the Electron bridge and
+ * calls `pa:window:setFullscreen` to change it. The main-process listener
+ * persists the change so it is restored on the next launch.
+ *
+ * If running outside Electron (browser, mobile), the bridge is absent and
+ * the toggle renders nothing. (#80)
+ */
+function FullscreenToggle(): JSX.Element | null {
+  const bridge = typeof window !== 'undefined'
+    ? (window as unknown as { politicalAscent?: { window?: { isFullscreen: () => Promise<boolean>; setFullscreen: (v: boolean) => Promise<boolean> } } }).politicalAscent?.window
+    : undefined;
+
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  // Initialise from the actual window state on mount.
+  useEffect(() => {
+    if (!bridge) return;
+    void bridge.isFullscreen().then(setIsFullscreen);
+  }, [bridge]);
+
+  if (!bridge) return null;
+
+  return (
+    <Toggle
+      label="Fullscreen on launch"
+      value={isFullscreen}
+      onChange={(v) => {
+        void bridge.setFullscreen(v).then((ok) => {
+          if (ok) setIsFullscreen(v);
+        });
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Summary
Addresses todo#78, todo#79, and todo#80 (Electron window experience).

## Changes

### Hide top menu bar (#79)
- `autoHideMenuBar: true` in `createMainWindow`. The File/View/Help menu is hidden at startup and reappears when Alt/F10 is pressed on Windows, keeping the game surface clean without permanently removing menu access.

### Fullscreen persistence (#80)
- On startup, `main.ts` reads `persist.get('settings').fullscreen` and calls `win.setFullScreen(true)` inside `ready-to-show` (avoids GPU black-flash on some hardware).
- `enter-full-screen` and `leave-full-screen` window events save the state back to electron-store immediately.
- Two new IPC handlers: `pa:window:setFullscreen(bool)` and `pa:window:isFullscreen()`.
- Preload bridge gains a `window` namespace exposing both methods.
- Settings screen Display card gains a `FullscreenToggle` component that reads the live window state on mount and calls through the bridge on change. No-ops gracefully in browser/mobile (bridge absent).

### Autosave system (#78)
- `GameEngineImpl` gains `autosaveWeekCounter` (private) and `AUTOSAVE_INTERVAL = 4` (static).
- Every weekly tick increments the counter; at 4 weeks `writeSave('autosave', 'Autosave')` is called fire-and-forget. The dedicated `autosave` slot is silently overwritten each interval.
- Counter resets in `teardown()` so starting a new game doesn't carry over a partial interval.

## Testing
- `npx tsc --noEmit` (web): exit 0
- `npx tsc -p tsconfig.electron.json --noEmit` (Electron): exit 0
- `npm run lint`: 0 errors, 0 warnings
- `npx vitest run`: 236/236 passed

## Docs
No GDD or ARCHITECTURE changes required. Changelog entry deferred to next bundle.

Refs todo#78, todo#79, todo#80
