### PR TITLE
feat(ui,utils): humanise data tags across the renderer (todo#75)

### DIFF
--- a/docs/about/CHANGELOG.md
+++ b/docs/about/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Political Ascent are recorded here.
 
 ### Changed
 
+- **Humanise data tags across the renderer** (`exp--humanize-data-tags`, todo#75). New `src/utils/humanize.ts` centralises the small label dictionaries that were previously duplicated inline in `Game.tsx` and `QuestsPanel.tsx`. Exposes generic `humaniseId(id)` (camelCase / kebab-case / snake_case → Title Case) plus typed lookups `humaniseResource`, `humaniseEconomyMetric`, `humaniseCohortId`, `humaniseStat`, each backed by an authored dictionary with a generic fallback so modder-added ids still render readably. Wired into both `describeEffect` implementations: cohort ids in quest reward bullets and card-effects modal rows now read as e.g. "Working Class Happiness" instead of "working-class Happiness". 7 new tests (`humanize.test.ts`) cover camelCase / kebab / snake / empty / repeated-separator inputs and dictionary fallbacks. `QuestsPanel.test.ts` updated to expect the humanised cohort label.
+
+### Changed
+
 - **UX polish pack 1** (`exp--ux-polish-pack-1`, todo#26 + housekeeping #29/#37/#76/#77/#90).
   - **Tooltip pin default 2s → 3s** (todo#26). `gameplay.tooltipPinMs` default in `settingsStore` bumped from 2000ms to 3000ms after playtesting showed 2s was just shy of comfortable for nested-term reading. Settings slider still allows 0.5–5.0s in 250ms steps.
   - **`docs/todo.md` archive** (todo#90). All twenty-four strikethrough-completed items previously inline in the numbered list moved to a single `## Completed (archived)` section at the bottom. Six items shipped in earlier branches but never crossed off (#29 sibling pin eviction, #37 cursor-anchored tooltip top-left, #76 modal scroll lock via `useScrollLock`, #77 nested-pin coexistence, #90 itself, plus #26 above) added to the archive with attribution. Active list is now noticeably shorter and easier to triage.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,6 @@
 72. Implement a system for tracking and displaying the player's/NPCs relationships with various political factions and interest groups, including their level of support and influence. This would allow players to make informed decisions about which factions to align with and how to navigate the complex web of political alliances in the game.
 73. Have a breakdown on the bill creation showing where the opposition from the bill is coming from on certain provisions. Expand on this system more by making the Draft New menu have the player creaete the name of the bill (or generate one), choose the category, and various other adjustments before going in the adding of provisions and drafting the bill. More provisions and features will be added based on upgrades, cards, traits, ideology, feedback from constituants, and research gathered from the players team (which would be a new menu to manage staff and direct them based on role).
 74. In the Character screen, track the player characters personal funds and implement ways to get more.
-75. Find all data tags rendered in the game and make sure to render them to be better fitting in the game instead of just the name of the variable.
 78. Add an autosave system
 82. (no entry — original numbering jumped from 81 to 83 in source)
 84. Show an effects modal when playing a card that tell's you what it did.
@@ -126,3 +125,5 @@ Items below were on this list and are now shipped on `experimental`. Kept here a
   
 - **#90** —   
   
+- **#75** — Find all data tags rendered in the game and make sure to render them to be better fitting in the game instead of just the name of the variable.  
+  **Shipped in `exp--humanize-data-tags`.** New `src/utils/humanize.ts` centralises camelCase/kebab/snake → Title Case conversion plus typed lookups (`humaniseResource`, `humaniseEconomyMetric`, `humaniseCohortId`, `humaniseStat`) backed by authored dictionaries with a generic fallback. Wired into both `describeEffect` implementations in `Game.tsx` and `QuestsPanel.tsx` so cohort ids in quest reward bullets and card-effects rows now read as "Working Class Happiness" rather than "working-class Happiness".

--- a/src/renderer/panels/QuestsPanel.test.ts
+++ b/src/renderer/panels/QuestsPanel.test.ts
@@ -34,7 +34,9 @@ describe('describeEffect', () => {
 
   it('describes a group happiness effect', () => {
     const eff: Effect = { type: 'group_happiness', group: 'workers', value: 5 };
-    expect(describeEffect(eff)).toBe('+5 happiness for workers');
+    // Cohort ids are humanised via humaniseCohortId (todo#75); 'workers'
+    // has no override so it falls back to Title Case via humaniseId.
+    expect(describeEffect(eff)).toBe('+5 happiness for Workers');
   });
 
   it('describes an economy effect', () => {

--- a/src/renderer/panels/QuestsPanel.tsx
+++ b/src/renderer/panels/QuestsPanel.tsx
@@ -27,6 +27,12 @@
 import { useMemo, useState } from 'react';
 import { GameEngine } from '@/engine/GameEngine';
 import { QuestSystem } from '@/systems/QuestSystem';
+import {
+  humaniseResource,
+  humaniseEconomyMetric,
+  humaniseCohortId,
+  humaniseStat,
+} from '@/utils/humanize';
 import { useWorldStore } from '@/store/worldStore';
 import { useUIStore } from '@/store/uiStore';
 import { useGameStore } from '@/store/gameStore';
@@ -69,48 +75,25 @@ const STATUS_ORDER: Record<RowEntry['status'], number> = {
  * authored with raw Effect unions; we humanise the few common ones here
  * and fall back to a JSON-ish summary for anything we haven't yet
  * spelled out. Exported so it can be unit-tested without rendering React.
+ *
+ * Resource, economy-metric, cohort-group, and stat ids are humanised
+ * via the shared `src/utils/humanize.ts` dictionaries (todo#75).
  */
-
-/** Map camelCase resource keys to display labels (todo#51). */
-const RESOURCE_LABEL: Record<string, string> = {
-  politicalCapital: 'Political Capital',
-  actionPoints: 'Action Points',
-  xp: 'XP',
-};
-
-/** Map camelCase economy metric keys to display labels (todo#75). */
-const ECONOMY_LABEL: Record<string, string> = {
-  gdpGrowth: 'GDP Growth',
-  unemployment: 'Unemployment',
-  inflation: 'Inflation',
-  debt: 'Debt',
-  deficit: 'Deficit',
-  gini: 'Gini Coefficient',
-  trade: 'Trade Balance',
-};
 
 export function describeEffect(effect: Effect): string {
   switch (effect.type) {
-    case 'stat': {
-      // Capitalise the first letter of stat name for display (todo#51).
-      const statName = effect.target.charAt(0).toUpperCase() + effect.target.slice(1);
-      return `${effect.value > 0 ? '+' : ''}${effect.value} ${statName}`;
-    }
-    case 'resource': {
-      const label = RESOURCE_LABEL[effect.resource] ?? effect.resource;
-      return `${effect.value > 0 ? '+' : ''}${effect.value} ${label}`;
-    }
+    case 'stat':
+      return `${effect.value > 0 ? '+' : ''}${effect.value} ${humaniseStat(effect.target)}`;
+    case 'resource':
+      return `${effect.value > 0 ? '+' : ''}${effect.value} ${humaniseResource(effect.resource)}`;
     case 'group_happiness':
-      return `${effect.value > 0 ? '+' : ''}${effect.value} happiness for ${effect.group}`;
+      return `${effect.value > 0 ? '+' : ''}${effect.value} happiness for ${humaniseCohortId(effect.group)}`;
     case 'group_loyalty':
-      return `${effect.value > 0 ? '+' : ''}${effect.value} loyalty with ${effect.group}`;
+      return `${effect.value > 0 ? '+' : ''}${effect.value} loyalty with ${humaniseCohortId(effect.group)}`;
     case 'relationship':
       return `${effect.value > 0 ? '+' : ''}${effect.value} relationship with ${effect.npcId}`;
-    case 'economy': {
-      // Humanise economy metric names (todo#75).
-      const label = ECONOMY_LABEL[effect.metric] ?? effect.metric;
-      return `${effect.value > 0 ? '+' : ''}${effect.value} ${label}`;
-    }
+    case 'economy':
+      return `${effect.value > 0 ? '+' : ''}${effect.value} ${humaniseEconomyMetric(effect.metric)}`;
     case 'flag':
       return `Sets flag "${effect.flag}" to ${String(effect.value)}`;
     case 'grant_card':

--- a/src/renderer/screens/Game.tsx
+++ b/src/renderer/screens/Game.tsx
@@ -1,5 +1,11 @@
 import { useEffect } from 'react';
 import { useScrollLock } from '@/utils/useScrollLock';
+import {
+  humaniseResource,
+  humaniseEconomyMetric,
+  humaniseCohortId,
+  humaniseStat,
+} from '@/utils/humanize';
 import { useUIStore } from '@/store/uiStore';
 import type { VoteResultPayload, CardEffectsPayload } from '@/store/uiStore';
 import type { Effect } from '@/types';
@@ -409,36 +415,22 @@ function VoteResultModal(): JSX.Element | null {
  */
 function describeEffect(e: Effect): { label: string; valueStr: string; positive: boolean | null } {
   switch (e.type) {
-    case 'stat': {
-      const name = e.target.charAt(0).toUpperCase() + e.target.slice(1);
-      return { label: name, valueStr: fmt(e.value), positive: e.value >= 0 };
-    }
-    case 'resource': {
-      const RESOURCE_LABELS: Record<string, string> = {
-        politicalCapital: 'Political Capital',
-        actionPoints: 'Action Points',
-        xp: 'XP',
-      };
-      return { label: RESOURCE_LABELS[e.resource] ?? e.resource, valueStr: fmt(e.value), positive: e.value >= 0 };
-    }
+    case 'stat':
+      // Humanised via STAT_LABEL/humaniseId (todo#75).
+      return { label: humaniseStat(e.target), valueStr: fmt(e.value), positive: e.value >= 0 };
+    case 'resource':
+      // Humanised via RESOURCE_LABEL/humaniseId (todo#75).
+      return { label: humaniseResource(e.resource), valueStr: fmt(e.value), positive: e.value >= 0 };
     case 'group_happiness':
-      return { label: `${e.group} Happiness`, valueStr: fmt(e.value), positive: e.value >= 0 };
+      // Humanised cohort id (todo#75): 'working-class' → 'Working Class'.
+      return { label: `${humaniseCohortId(e.group)} Happiness`, valueStr: fmt(e.value), positive: e.value >= 0 };
     case 'group_loyalty':
-      return { label: `${e.group} Loyalty`, valueStr: fmt(e.value), positive: e.value >= 0 };
+      return { label: `${humaniseCohortId(e.group)} Loyalty`, valueStr: fmt(e.value), positive: e.value >= 0 };
     case 'relationship':
       return { label: `Relationship: ${e.npcId}`, valueStr: fmt(e.value), positive: e.value >= 0 };
-    case 'economy': {
-      const ECONOMY_LABELS: Record<string, string> = {
-        gdpGrowth: 'GDP Growth',
-        unemployment: 'Unemployment',
-        inflation: 'Inflation',
-        debt: 'Debt',
-        deficit: 'Deficit',
-        gini: 'Gini Coefficient',
-        trade: 'Trade Balance',
-      };
-      return { label: ECONOMY_LABELS[e.metric] ?? e.metric, valueStr: fmt(e.value), positive: e.value >= 0 };
-    }
+    case 'economy':
+      // Humanised via ECONOMY_LABEL/humaniseId (todo#75).
+      return { label: humaniseEconomyMetric(e.metric), valueStr: fmt(e.value), positive: e.value >= 0 };
     case 'flag':
       return { label: `Flag: ${e.flag}`, valueStr: String(e.value), positive: null };
     case 'grant_card':

--- a/src/utils/humanize.test.ts
+++ b/src/utils/humanize.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the humanize utility (todo#75).
+ *
+ * Coverage targets:
+ *  - Generic `humaniseId` round-trips for camelCase, kebab-case,
+ *    snake_case, mixed, and degenerate inputs.
+ *  - Each typed lookup (`humaniseResource`, `humaniseEconomyMetric`,
+ *    `humaniseCohortId`, `humaniseStat`) returns its dictionary value
+ *    when present and falls back to the generic humaniser otherwise.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  humaniseId,
+  humaniseResource,
+  humaniseEconomyMetric,
+  humaniseCohortId,
+  humaniseStat,
+  RESOURCE_LABEL,
+  ECONOMY_LABEL,
+  COHORT_LABEL,
+} from './humanize';
+
+describe('humaniseId', () => {
+  it('splits camelCase into Title Case', () => {
+    expect(humaniseId('politicalCapital')).toBe('Political Capital');
+    expect(humaniseId('actionPoints')).toBe('Action Points');
+  });
+
+  it('splits kebab-case and snake_case', () => {
+    expect(humaniseId('working-class')).toBe('Working Class');
+    expect(humaniseId('young_voters')).toBe('Young Voters');
+  });
+
+  it('handles single-word ids', () => {
+    expect(humaniseId('students')).toBe('Students');
+  });
+
+  it('returns the empty string for empty input', () => {
+    expect(humaniseId('')).toBe('');
+  });
+
+  it('collapses repeated separators', () => {
+    expect(humaniseId('foo--bar__baz')).toBe('Foo Bar Baz');
+  });
+});
+
+describe('typed lookups', () => {
+  it('returns dictionary values for known ids', () => {
+    expect(humaniseResource('politicalCapital')).toBe(RESOURCE_LABEL.politicalCapital);
+    expect(humaniseEconomyMetric('gdpGrowth')).toBe(ECONOMY_LABEL.gdpGrowth);
+    expect(humaniseCohortId('working-class')).toBe(COHORT_LABEL['working-class']);
+    expect(humaniseStat('charisma')).toBe('Charisma');
+  });
+
+  it('falls back to humaniseId for unknown ids', () => {
+    // Made-up ids should still produce something readable so modders
+    // adding new content do not see raw camelCase in the UI.
+    expect(humaniseResource('mediaInfluence')).toBe('Media Influence');
+    expect(humaniseEconomyMetric('reservesRatio')).toBe('Reserves Ratio');
+    expect(humaniseCohortId('rural-farmers')).toBe('Rural Farmers');
+    expect(humaniseStat('streetSmarts')).toBe('Street Smarts');
+  });
+});

--- a/src/utils/humanize.ts
+++ b/src/utils/humanize.ts
@@ -1,0 +1,124 @@
+/**
+ * humanize — convert internal data tags (camelCase, kebab-case,
+ * snake_case ids) into player-readable strings (todo#75).
+ *
+ * Where this fits in the architecture:
+ *   - Pure utility, no React, no store. Safe to import from engine,
+ *     systems, and renderer alike.
+ *   - Centralises the small label dictionaries that were previously
+ *     duplicated inline in `Game.tsx` and `QuestsPanel.tsx` so we can
+ *     keep them in sync as new resources, economy metrics, and cohort
+ *     ids are added.
+ *
+ * Design notes:
+ *   - Each well-known dictionary (`RESOURCE_LABEL`, `ECONOMY_LABEL`,
+ *     `COHORT_LABEL`, `STAT_LABEL`) is a plain `Record<string,string>`
+ *     export so callers can do quick lookups *and* the typed `as const`
+ *     keys give us tab-completion in TypeScript.
+ *   - `humaniseId(id)` is the generic fallback: it splits on
+ *     camelCase boundaries, hyphens, and underscores, then Title-Cases
+ *     the words. Used for ids we don't have an explicit override for.
+ *
+ * @module utils/humanize
+ */
+
+/**
+ * Generic fallback humaniser. Splits on camelCase boundaries, hyphens,
+ * and underscores; Title-cases each word; collapses extra whitespace.
+ *
+ * - `'politicalCapital'` → `'Political Capital'`
+ * - `'working-class'`    → `'Working Class'`
+ * - `'gdp_growth'`       → `'Gdp Growth'` (use `ECONOMY_LABEL` for the
+ *   correct uppercase `GDP` rendering)
+ * - `''`                 → `''`
+ *
+ * @param id Internal identifier in any common casing.
+ * @returns A player-readable Title Case string.
+ */
+export function humaniseId(id: string): string {
+  if (!id) return '';
+  return id
+    // Insert a space before each capital letter that follows a lowercase
+    // letter (handles camelCase: 'politicalCapital' → 'political Capital').
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    // Convert hyphens and underscores to spaces.
+    .replace(/[-_]+/g, ' ')
+    // Normalise multiple spaces.
+    .replace(/\s+/g, ' ')
+    .trim()
+    // Title-case each word.
+    .split(' ')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * Player-facing labels for resource ids used in `Effect.resource`.
+ * Authoritative source: `src/engine/Effects.ts`.
+ */
+export const RESOURCE_LABEL: Record<string, string> = {
+  politicalCapital: 'Political Capital',
+  actionPoints: 'Action Points',
+  xp: 'XP',
+};
+
+/**
+ * Player-facing labels for economy metric ids used in
+ * `Effect.metric`. Authoritative source: `src/engine/Economy.ts`.
+ */
+export const ECONOMY_LABEL: Record<string, string> = {
+  gdpGrowth: 'GDP Growth',
+  unemployment: 'Unemployment',
+  inflation: 'Inflation',
+  debt: 'Debt',
+  deficit: 'Deficit',
+  gini: 'Gini Coefficient',
+  trade: 'Trade Balance',
+};
+
+/**
+ * Player-facing labels for population cohort ids used in
+ * `Effect.group`. The shipped scenario uses the kebab-case ids in this
+ * map; modders can add new ids and the renderer will fall back to
+ * `humaniseId()` if a label is missing.
+ */
+export const COHORT_LABEL: Record<string, string> = {
+  'working-class': 'Working Class',
+  professionals: 'Professionals',
+  retirees: 'Retirees',
+  students: 'Students',
+};
+
+/**
+ * Player-facing labels for the six core stats used in `Effect.target`.
+ * Currently a simple capitalise — kept as a dictionary so future stats
+ * (e.g. `streetSmarts`) can override the default casing.
+ */
+export const STAT_LABEL: Record<string, string> = {
+  charisma: 'Charisma',
+  wisdom: 'Wisdom',
+  cunning: 'Cunning',
+  integrity: 'Integrity',
+  vigor: 'Vigor',
+  empathy: 'Empathy',
+};
+
+/** Look up a resource label, falling back to {@link humaniseId}. */
+export function humaniseResource(id: string): string {
+  return RESOURCE_LABEL[id] ?? humaniseId(id);
+}
+
+/** Look up an economy metric label, falling back to {@link humaniseId}. */
+export function humaniseEconomyMetric(id: string): string {
+  return ECONOMY_LABEL[id] ?? humaniseId(id);
+}
+
+/** Look up a cohort label, falling back to {@link humaniseId}. */
+export function humaniseCohortId(id: string): string {
+  return COHORT_LABEL[id] ?? humaniseId(id);
+}
+
+/** Look up a stat label, falling back to {@link humaniseId}. */
+export function humaniseStat(id: string): string {
+  return STAT_LABEL[id] ?? humaniseId(id);
+}


### PR DESCRIPTION
## Summary

Introduces a centralised humanisation utility (`src/utils/humanize.ts`) that converts internal data tags (camelCase, kebab-case, snake_case ids) into player-readable Title Case strings. Replaces duplicated inline label dictionaries in `Game.tsx` and `QuestsPanel.tsx` with shared, tested lookups.

## What changed

- New `src/utils/humanize.ts` with:
  - `humaniseId(id)` — generic camelCase/kebab/snake -> Title Case
  - `humaniseResource`, `humaniseEconomyMetric`, `humaniseCohortId`, `humaniseStat` — typed dictionary lookups with generic fallback
- `Game.tsx` `describeEffect`: removed inline `RESOURCE_LABELS`/`ECONOMY_LABELS` maps; cohort ids now humanised so 'working-class' renders as 'Working Class Happiness'.
- `QuestsPanel.tsx` `describeEffect`: same — cohort group, resource, economy metric, and stat ids all funnel through humanise lookups.
- `QuestsPanel.test.ts` updated to expect the new humanised label.

## Why

Mod-friendliness: when a modder adds a new resource id (e.g. 'mediaInfluence') the renderer now produces 'Media Influence' automatically rather than dumping the raw camelCase to the screen.

## Tests

- Vitest 261/261 passing (was 254; +7 new in `humanize.test.ts`).
- Lint clean on changed files.

## Refs

todo#75