### PR TITLE
fix(dev): resolve baseline typecheck and build errors

### DIFF
--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -19,7 +19,6 @@
     "isolatedModules": true,
     "useDefineForClassFields": true,
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"]
     },


### PR DESCRIPTION
Fixes TypeScript typecheck errors and build failures blocking development baseline.

- Resolves typecheck failures surfacing on all PRs targeting \development\
- Ensures \
pm run build\ and \	sc\ pass cleanly

Unblocks: #124 #125 #127 #129 #132 #134

- Jesse